### PR TITLE
Fix for service-node client-import.json file

### DIFF
--- a/service-nodejs/client-import.json
+++ b/service-nodejs/client-import.json
@@ -1,5 +1,5 @@
 {
-    "resource": "service-nodejs",
+    "clientId": "service-nodejs",
     "enabled": true,
     "bearerOnly": true
 }


### PR DESCRIPTION
If users attempt to import this file, it will fail due to misconfiguration. This PR fixes it.