### PR TITLE
Adds a new quickstart for AuthZ and SpringBoot REST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - TESTS=group2
     - TESTS=group3
     - TESTS=group4
+    - TESTS=group5
 
 before_install:
   - ./travis-server.sh

--- a/app-authz-rest-springboot/README.md
+++ b/app-authz-rest-springboot/README.md
@@ -1,0 +1,179 @@
+app-authz-rest-springboot: SpringBoot REST Service Protected Using Keycloak Authorization Services
+===================================================
+
+Level: Beginner
+Technologies: SpringBoot
+Summary: SpringBoot REST Service Protected Using Keycloak Authorization Services
+Target Product: Keycloak
+Source: <https://github.com/keycloak/Keycloak-quickstarts>
+
+
+What is it?
+-----------
+
+The `app-authz-rest-springboot` quickstart demonstrates how to protect a SpringBoot REST service using Keycloak Authorization Services.
+
+This application tries to focus on the authorization features provided by Keycloak Authorization Services, where resources are
+protected by a set of permissions and policies defined in Keycloak itself and access to these resources are enforced by a policy enforcer
+that intercepts every single request to the application.
+
+In this application, there are three paths protected by specific permissions in Keycloak:
+
+* **/api/{resource}**, where access to this page is based on the evaluation of permissions associated with a resource **Default Resource** in Keycloak. Basically,
+any user with a role *user* is allowed to access this page. Examples of resource that match this path pattern are: "/api/resourcea" and "/api/resourceb".
+
+* **/api/premium**, where access to this page is based on the evaluation of permissions associated with a resource **Premium Resource** in Keycloak. Basically,
+only users with a role *user-premium* is allowed to access this page.
+
+You can use two distinct users to access this application:
+
+|Username|Password|Roles|
+|---|---|---|
+|alice|alice|user|
+|jdoe|jdoe|user, user-premium|
+
+System Requirements
+-------------------
+
+All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.1.1 or later.
+
+
+Configuration in Keycloak
+-----------------------
+
+Prior to running the quickstart you need to create a `realm` in Keycloak with all the necessary configuration to deploy and run the quickstart.
+
+The following steps show how to create the realm required for this quickstart:
+
+* Open the Keycloak admin console
+* In the top left corner dropdown menu that is titled `Master`, click `Add Realm`. If you are logged in to the master realm this dropdown menu lists all the realms created.
+* For this quickstart we are not going to manually create the realm, but import all configuration from a JSON file. Click on `Select File` and import the [config/realm-import.json](config/realm-import.json).
+* Click `Create`
+
+The steps above will result on a new `spring-boot-quickstart` realm.
+
+Build and Run the Quickstart
+-------------------------------
+
+Make sure your Keycloak server is running on <http://localhost:8180/>. For that, you can start the server using the command below:
+
+   ````
+   cd {KEYCLOAK_HOME}/bin
+   ./standalone.sh -Djboss.socket.binding.port-offset=100
+   
+   ````
+
+If your server is up and running, perform the following steps to start the application:
+
+1. Open a terminal and navigate to the root directory of this quickstart.
+
+2. The following shows the command to deploy the quickstart:
+
+   ````
+   mvn spring-boot:run
+
+   ````
+
+Access the Quickstart
+---------------------
+
+In order to understand better what is happening behind the scenes, we describe some steps using Curl to exemplify 
+how clients can get access to the RESTful resources provided by this application.
+
+First thing, your client needs to obtain an OAuth2 access token from a Keycloak server.
+
+```bash
+curl -X POST \
+  http://localhost:8180/auth/realms/spring-boot-quickstart/protocol/openid-connect/token \
+  -H 'Authorization: Basic YXBwLWF1dGh6LXJlc3Qtc3ByaW5nYm9vdDpzZWNyZXQ=' \
+  -H 'content-type: application/x-www-form-urlencoded' \
+  -d 'username=alice&password=alice&grant_type=password'
+```
+
+After executing the command above, you should get a response similar to the following:
+
+```bash
+{
+    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJGSjg2R2NGM2pUYk5MT2NvNE52WmtVQ0lVbWZZQ3FvcXRPUWVNZmJoTmxFIn0.eyJqdGkiOiI3OWY4NmFjZS01Zjk4LTQ0MTctYWJmZC0xMjcyOGQ2OGJkNDEiLCJleHAiOjE1MDQxOTE5MzYsIm5iZiI6MCwiaWF0IjoxNTA0MTkxNjM2LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgxODAvYXV0aC9yZWFsbXMvc3ByaW5nLWJvb3QtcXVpY2tzdGFydCIsImF1ZCI6ImFwcC1hdXRoei1yZXN0LXNwcmluZ2Jvb3QiLCJzdWIiOiJlNmE3NzcyYS1kZmZlLTRiNDItYTFiMS0zZDZmOTM0OWE0NmIiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJhcHAtYXV0aHotcmVzdC1zcHJpbmdib290IiwiYXV0aF90aW1lIjowLCJzZXNzaW9uX3N0YXRlIjoiNzE4MmU0YzEtNzY5ZS00MTNlLWI2MWItM2FlZTFjYWZmY2JmIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwOi8vbG9jYWxob3N0OjgwODAiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbInVzZXIiXX0sInJlc291cmNlX2FjY2VzcyI6e30sInByZWZlcnJlZF91c2VybmFtZSI6ImFsaWNlIn0.bpKwmY2CqEm1TLYZoC_6jG0V1XcLKC2dStTAnUJgUMQfTBn3kZHsrWZeahKq7IdVocn7bWoBU0mP8i0rf89GcoZS1j-oju32XArTtE2e-tWVeWaRa1vJHNjhsIAuvZ4CmRh6QOTa-0qowbi1oEZxL3aQ6jPL4OSjBOAJgS51tn4",
+    "expires_in":300,
+    "refresh_expires_in":1800,
+    "refresh_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJGSjg2R2NGM2pUYk5MT2NvNE52WmtVQ0lVbWZZQ3FvcXRPUWVNZmJoTmxFIn0.eyJqdGkiOiI2Mzk3MDRhOS1jYTg1LTQxOWYtODA5Yi03MDkzOGQyNzQwNTQiLCJleHAiOjE1MDQxOTM0MzYsIm5iZiI6MCwiaWF0IjoxNTA0MTkxNjM2LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgxODAvYXV0aC9yZWFsbXMvc3ByaW5nLWJvb3QtcXVpY2tzdGFydCIsImF1ZCI6ImFwcC1hdXRoei1yZXN0LXNwcmluZ2Jvb3QiLCJzdWIiOiJlNmE3NzcyYS1kZmZlLTRiNDItYTFiMS0zZDZmOTM0OWE0NmIiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoiYXBwLWF1dGh6LXJlc3Qtc3ByaW5nYm9vdCIsImF1dGhfdGltZSI6MCwic2Vzc2lvbl9zdGF0ZSI6IjcxODJlNGMxLTc2OWUtNDEzZS1iNjFiLTNhZWUxY2FmZmNiZiIsInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ1c2VyIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnt9fQ.CV3tZfYylhXMK7F0ozf-u4AZx_edm0FhdIDYiRDbhM3trRFzmpaRtuwML2KethVqj01PhD0VYYjt2yK0GWgkFswW1tc-Rqq2TMjabeGTcLPwvb8NZ7FcZnwglZUU46mfuV8-m1Idzqgs5DhmpkBALkAXjeaVPedAMNsPFQSPJE4",
+    "token_type":"bearer",
+    "not-before-policy":0,
+    "session_state":"7182e4c1-769e-413e-b61b-3aee1caffcbf"
+}
+```
+Now replace the ``${access_token}`` variable below with the value of the ``access_token`` claim from the response. 
+
+```bash
+curl -X POST \
+  http://localhost:8180/auth/realms/spring-boot-quickstart/authz/entitlement/app-authz-rest-springboot \
+  -H "Authorization: Bearer ${access_token}" \
+  -H 'Content-type: application/json' \
+  -d '{
+	"permissions": [
+		{
+			"resource_set_name": "Default Resource"
+		}	
+	]
+}'
+```
+
+As an alternative, you can also obtain permissions for any resource protected by your application. For that, execute the command below:
+
+```bash
+curl -X GET \
+    http://localhost:8180/auth/realms/spring-boot-quickstart/authz/entitlement/app-authz-rest-springboot \
+    -H "Authorization: Bearer ${access_token}"
+```
+
+After executing the command above, you should get a response similar to the following:
+
+```bash
+{
+    "rpt": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJGSjg2R2NGM2pUYk5MT2NvNE52WmtVQ0lVbWZZQ3FvcXRPUWVNZmJoTmxFIn0.eyJqdGkiOiIzYzI2NmZhOS01NmZlLTQ0MjItODg4Ni0xMmRjYTRlZTYyMTYiLCJleHAiOjE1MDQxOTIwNDQsIm5iZiI6MCwiaWF0IjoxNTA0MTkxNzQ0LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgxODAvYXV0aC9yZWFsbXMvc3ByaW5nLWJvb3QtcXVpY2tzdGFydCIsImF1ZCI6ImFwcC1hdXRoei1yZXN0LXNwcmluZ2Jvb3QiLCJzdWIiOiJlNmE3NzcyYS1kZmZlLTRiNDItYTFiMS0zZDZmOTM0OWE0NmIiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJhcHAtYXV0aHotcmVzdC1zcHJpbmdib290IiwiYXV0aF90aW1lIjowLCJzZXNzaW9uX3N0YXRlIjoiMGQ2NTQ0YzMtZmY2Yi00ZGU4LTk5YzEtNDM2ZDg2YzkyNzIxIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWxpY2UiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly9sb2NhbGhvc3Q6ODA4MCJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsidXNlciJdfSwicmVzb3VyY2VfYWNjZXNzIjp7fSwiYXV0aG9yaXphdGlvbiI6eyJwZXJtaXNzaW9ucyI6W3sicmVzb3VyY2Vfc2V0X2lkIjoiNDIwZGMxNzktZTY5OC00ZmYzLTkyMTgtMWE0YmQ5N2I2ZjU5IiwicmVzb3VyY2Vfc2V0X25hbWUiOiJEZWZhdWx0IFJlc291cmNlIn1dfX0.m6ePUAiAGkRlAQWvroiRq4EwqTNGxsc3TtW0YbFeF_n8WrzJA38mIwrnU-D1fFSXBvA3SxPImf4y9er5Zo31ZMtBNhns4-yl850JPEoApJoaUHeL_PMCvN9zwvIi4IN4-wl58yOjQ1MzJ50SOpiJKfp7VXLgJQkj8OodMctz0GE"
+}
+```
+
+Finally, you are able to access the RESTFul resources protected by this application with a RPT (Requesting Party Token). For that, replace the ``${rpt}`` variable below with the value of the ``rpt`` claim from the response.
+
+```bash
+curl -X GET \
+  http://localhost:8080/api/resourcea \
+  -H 'Authorization: Bearer ${rpt}'
+```
+
+User *alice* should be able to access */api/resourcea* and you should get **Access Granted** as a response. Now, if you try to access */api/premium* as *alice* you should
+get a **403** HTTP status code.
+
+You should also get a **403** HTTP status code if you try to obtain permissions from Keycloak for "Premium Resource".
+
+```bash
+curl -X POST \
+  http://localhost:8180/auth/realms/spring-boot-quickstart/authz/entitlement/app-authz-rest-springboot \
+  -H "Authorization: Bearer ${access_token}" \
+  -H 'Content-type: application/json' \
+  -d '{
+	"permissions": [
+		{
+			"resource_set_name": "Premium Resource"
+		}	
+	]
+}'
+```
+
+As a response you should get something similar to the following:
+
+```bash
+{"error":"not_authorized"}
+```
+
+You can follow the same steps to check behavior when accessing the same resources with user *jdoe*.
+
+Integration test of the Quickstart
+----------------------------------
+
+1. Make sure you have an Keycloak server running with an admin user in the `master` realm or use the provided docker image
+2. Be sure to set the `TestHelper.keycloakBaseUrl` in the `createArchive` method (default URL is localhost:8180/auth).
+3. Set accordingly the correct url for the `keycloak.auth-server-url` in the test [application.properties](src/test/resources/application.properties).
+4. Run `mvn test`

--- a/app-authz-rest-springboot/config/quickstart-realm.json
+++ b/app-authz-rest-springboot/config/quickstart-realm.json
@@ -1,0 +1,129 @@
+{
+    "realm": "spring-boot-quickstart",
+    "enabled": true,
+    "privateKey": "MIICXAIBAAKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQABAoGAfmO8gVhyBxdqlxmIuglbz8bcjQbhXJLR2EoS8ngTXmN1bo2L90M0mUKSdc7qF10LgETBzqL8jYlQIbt+e6TH8fcEpKCjUlyq0Mf/vVbfZSNaVycY13nTzo27iPyWQHK5NLuJzn1xvxxrUeXI6A2WFpGEBLbHjwpx5WQG9A+2scECQQDvdn9NE75HPTVPxBqsEd2z10TKkl9CZxu10Qby3iQQmWLEJ9LNmy3acvKrE3gMiYNWb6xHPKiIqOR1as7L24aTAkEAtyvQOlCvr5kAjVqrEKXalj0Tzewjweuxc0pskvArTI2Oo070h65GpoIKLc9jf+UA69cRtquwP93aZKtW06U8dQJAF2Y44ks/mK5+eyDqik3koCI08qaC8HYq2wVl7G2QkJ6sbAaILtcvD92ToOvyGyeE0flvmDZxMYlvaZnaQ0lcSQJBAKZU6umJi3/xeEbkJqMfeLclD27XGEFoPeNrmdx0q10Azp4NfJAY+Z8KRyQCR2BEG+oNitBOZ+YXF9KCpH3cdmECQHEigJhYg+ykOvr1aiZUMFT72HU0jnmQe2FVekuG+LJUt2Tm7GtMjTFoGpf0JwrVuZN39fOYAlo+nTixgeW7X8Y=",
+    "publicKey": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB",
+    "requiredCredentials": [
+        "password"
+    ],
+    "users": [
+        {
+            "username": "alice",
+            "enabled": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "alice"
+                }
+            ],
+            "realmRoles": [
+                "user"
+            ]
+        },
+        {
+            "username": "jdoe",
+            "enabled": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "jdoe"
+                }
+            ],
+            "realmRoles": [
+                "user",
+                "user-premium"
+            ]
+        },
+        {
+            "username": "service-account-app-authz-rest-springboot",
+            "enabled": true,
+            "serviceAccountClientId": "app-authz-rest-springboot",
+            "clientRoles": {
+                "app-authz-rest-springboot": [
+                    "uma_protection"
+                ]
+            }
+        }
+    ],
+    "roles": {
+        "realm": [
+            {
+                "name": "user",
+                "description": "User privileges"
+            },
+            {
+                "name": "user-premium",
+                "description": "User premium privileges"
+            }
+        ]
+    },
+    "clients": [
+        {
+            "clientId": "app-authz-rest-springboot",
+            "enabled": true,
+            "baseUrl": "http://localhost:8080",
+            "adminUrl": "http://localhost:8080",
+            "redirectUris": [
+                "http://localhost:8080/*"
+            ],
+            "secret": "secret",
+            "directAccessGrantsEnabled": true,
+            "authorizationServicesEnabled": true,
+            "authorizationSettings": {
+                "allowRemoteResourceManagement": false,
+                "policyEnforcementMode": "ENFORCING",
+                "resources": [
+                    {
+                        "name": "Default Resource",
+                        "uri": "/api/{resource}"
+                    },
+                    {
+                        "name": "Premium Resource",
+                        "uri": "/api/premium"
+                    }
+                ],
+                "policies": [
+                    {
+                        "name": "Only Premium User Policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"user-premium\",\"required\":false}]"
+                        }
+                    },
+                    {
+                        "name": "Only User Policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"user\",\"required\":false}]"
+                        }
+                    },
+                    {
+                        "name": "Default Resource Permission",
+                        "description": "A permission that applies to the default resource",
+                        "type": "resource",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"Default Resource\"]",
+                            "applyPolicies": "[\"Only User Policy\"]"
+                        }
+                    },
+                    {
+                        "name": "Premium Resource Permission",
+                        "type": "resource",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"Premium Resource\"]",
+                            "applyPolicies": "[\"Only Premium User Policy\"]"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>3.3.0.CR1-SNAPSHOT</version>
+        <version>3.4.0.CR1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.keycloak.quickstarts</groupId>
+        <artifactId>keycloak-quickstart-parent</artifactId>
+        <version>3.3.0.CR1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>app-authz-rest-springboot</artifactId>
+    <name>Spring Boot Web Keycloak Authorization Services Sample</name>
+    <description>Spring Boot REST Keycloak Example using Authorization Services</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <springboot-version>1.5.3.RELEASE</springboot-version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-freemarker</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Keycloak  -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-authz-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-test-helper</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>htmlunit-driver</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>1.5.3.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak.bom</groupId>
+                <artifactId>keycloak-adapter-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/app-authz-rest-springboot/src/main/java/org/keycloak/quickstart/springboot/MyApplication.java
+++ b/app-authz-rest-springboot/src/main/java/org/keycloak/quickstart/springboot/MyApplication.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.keycloak.quickstart.springboot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@SpringBootApplication
+public class MyApplication {
+
+	public static void main(String[] args) throws Exception {
+		SpringApplication.run(MyApplication.class, args);
+	}
+}

--- a/app-authz-rest-springboot/src/main/java/org/keycloak/quickstart/springboot/web/ApplicationController.java
+++ b/app-authz-rest-springboot/src/main/java/org/keycloak/quickstart/springboot/web/ApplicationController.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.keycloak.quickstart.springboot.web;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@RestController
+public class ApplicationController {
+
+    @RequestMapping(value = "/api/resourcea", method = RequestMethod.GET)
+    public String handleResourceA() {
+        return "Access Granted";
+    }
+
+    @RequestMapping(value = "/api/resourceb", method = RequestMethod.GET)
+    public String handleResourceB() {
+        return "Access Granted";
+    }
+
+    @RequestMapping(value = "/api/premium", method = RequestMethod.GET)
+    public String handlePremiumResource() {
+        return "Access Granted";
+    }
+}

--- a/app-authz-rest-springboot/src/main/resources/application.properties
+++ b/app-authz-rest-springboot/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+server.connection-timeout=5000
+server.port = 8080
+keycloak.realm=spring-boot-quickstart
+keycloak.auth-server-url=http://localhost:8180/auth
+keycloak.ssl-required=external
+keycloak.resource=app-authz-rest-springboot
+keycloak.bearer-only=true
+keycloak.credentials.secret=secret
+keycloak.securityConstraints[0].authRoles[0]=user
+keycloak.securityConstraints[0].securityCollections[0].name=protected
+keycloak.securityConstraints[0].securityCollections[0].patterns[0]=/*
+keycloak.policy-enforcer-config.on-deny-redirect-to=/accessDenied

--- a/app-authz-rest-springboot/src/test/java/org/keycloak/quickstart/springboot/MyAppTest.java
+++ b/app-authz-rest-springboot/src/test/java/org/keycloak/quickstart/springboot/MyAppTest.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.keycloak.quickstart.springboot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.Configuration;
+import org.keycloak.authorization.client.representation.EntitlementRequest;
+import org.keycloak.authorization.client.representation.PermissionRequest;
+import org.keycloak.test.TestsHelper;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment= SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {MyApplication.class})
+public class MyAppTest {
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        TestsHelper.baseUrl = "http://localhost:8080";
+        TestsHelper.testRealm="spring-boot-quickstart";
+        TestsHelper.importTestRealm("admin","admin","/quickstart-realm.json");
+        TestsHelper.createDirectGrantClient();
+    }
+
+    @AfterClass
+    public static void cleanUp() throws IOException{
+        TestsHelper.deleteRealm("admin","admin", "spring-boot-quickstart");
+    }
+
+    @Test
+    public void testAccessToPathsMappedWithDefaultResource() throws IOException {
+        HttpResponse response = makeRequest("http://localhost:8080/api/resourcea", "alice", "alice", false, new PermissionRequest("Default Resource"));
+
+        // without a RPT, access should be denied
+        assertEquals(401, response.getStatusLine().getStatusCode());
+
+        response = makeRequest("http://localhost:8080/api/resourcea", "alice", "alice", true, new PermissionRequest("Default Resource"));
+
+        // we got a RPT from Keycloak with the necessary permissions to access the requested resource
+        assertAccessGranted(response);
+
+        response = makeRequest("http://localhost:8080/api/resourceb", "alice", "alice", true, new PermissionRequest("Default Resource"));
+
+        // we got a RPT from Keycloak with the necessary permissions to access the requested resource
+        assertAccessGranted(response);
+    }
+
+    @Test
+    public void testAccessToPathsMappedWithPremiumResource() throws IOException {
+        HttpResponse response = makeRequest("http://localhost:8080/api/premium", "jdoe", "jdoe", false, new PermissionRequest("Premium Resource"));
+
+        // without a RPT, access should be denied
+        assertEquals(401, response.getStatusLine().getStatusCode());
+
+        response = makeRequest("http://localhost:8080/api/premium", "jdoe", "jdoe", true, new PermissionRequest("Premium Resource"));
+
+        // we got a RPT from Keycloak with the necessary permissions to access the requested resource
+        assertAccessGranted(response);
+
+        response = makeRequest("http://localhost:8080/api/resourceb", "jdoe", "jdoe", true, new PermissionRequest("Default Resource"));
+
+        // we got a RPT from Keycloak with the necessary permissions to access the requested resource
+        assertAccessGranted(response);
+
+        try {
+            // alice can't access the requested resource because only "premium" users are allowed to do so
+            response = makeRequest("http://localhost:8080/api/premium", "alice", "alice", true, new PermissionRequest("Premium Resource"));
+            fail("Should fail, user alice is not supposed to have access to premium resources (missing user-premium role)");
+        } catch (AuthorizationDeniedException ignore) {
+        }
+    }
+
+    @Test
+    public void testAccessToUnknownPathsShouldBeDenied() throws IOException {
+        HttpResponse response = makeRequest("http://localhost:8080/unknownResource", "alice", "alice", true, new PermissionRequest("Default Resource"));
+        assertEquals(403, response.getStatusLine().getStatusCode());
+    }
+
+    private HttpResponse makeRequest(String uri, String userName, String password, boolean sendRpt, PermissionRequest permissionRequest) throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
+        HttpGet request = new HttpGet(uri);
+        String accessToken = TestsHelper.getToken(userName, password, TestsHelper.testRealm);
+        String rpt;
+
+        if (sendRpt) {
+            rpt = obtainRequestingPartyToken(permissionRequest, accessToken);
+        } else {
+            rpt = accessToken;
+        }
+
+        request.addHeader("Authorization", "Bearer " + rpt);
+
+        return client.execute(request);
+    }
+
+    /**
+     * Obtain a RPT from a Keycloak server. The RPT is a result of the evaluation of all policies associated with the resources being
+     * requested as defined by <code>permissionRequest</code>.
+     *
+     * @param permissionRequest the permission request
+     * @param accessToken an OAuth2 access token previously issued by Keycloak
+     * @return
+     */
+    private String obtainRequestingPartyToken(PermissionRequest permissionRequest, String accessToken) {
+        Configuration configuration = new Configuration();
+
+        configuration.setAuthServerUrl(TestsHelper.keycloakBaseUrl);
+        configuration.setRealm(TestsHelper.testRealm);
+
+        AuthzClient authzClient = AuthzClient.create(configuration);
+
+        EntitlementRequest entitlementRequest = new EntitlementRequest();
+
+        entitlementRequest.addPermission(permissionRequest);
+
+        return authzClient.entitlement(accessToken).get("app-authz-rest-springboot", entitlementRequest).getRpt();
+    }
+
+    private void assertAccessGranted(HttpResponse response) throws IOException {
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("Access Granted", EntityUtils.toString(response.getEntity()));
+    }
+}

--- a/app-authz-rest-springboot/src/test/resources/application.properties
+++ b/app-authz-rest-springboot/src/test/resources/application.properties
@@ -1,0 +1,12 @@
+server.connection-timeout=5000
+server.port = 8080
+keycloak.realm=spring-boot-quickstart
+keycloak.auth-server-url=http://localhost:8180/auth
+keycloak.ssl-required=external
+keycloak.resource=app-authz-rest-springboot
+keycloak.bearer-only=true
+keycloak.credentials.secret=secret
+keycloak.securityConstraints[0].authRoles[0]=user
+keycloak.securityConstraints[0].securityCollections[0].name=protected
+keycloak.securityConstraints[0].securityCollections[0].patterns[0]=/*
+keycloak.policy-enforcer-config.on-deny-redirect-to=/accessDenied

--- a/app-authz-rest-springboot/src/test/resources/quickstart-realm.json
+++ b/app-authz-rest-springboot/src/test/resources/quickstart-realm.json
@@ -1,0 +1,129 @@
+{
+    "realm": "spring-boot-quickstart",
+    "enabled": true,
+    "privateKey": "MIICXAIBAAKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQABAoGAfmO8gVhyBxdqlxmIuglbz8bcjQbhXJLR2EoS8ngTXmN1bo2L90M0mUKSdc7qF10LgETBzqL8jYlQIbt+e6TH8fcEpKCjUlyq0Mf/vVbfZSNaVycY13nTzo27iPyWQHK5NLuJzn1xvxxrUeXI6A2WFpGEBLbHjwpx5WQG9A+2scECQQDvdn9NE75HPTVPxBqsEd2z10TKkl9CZxu10Qby3iQQmWLEJ9LNmy3acvKrE3gMiYNWb6xHPKiIqOR1as7L24aTAkEAtyvQOlCvr5kAjVqrEKXalj0Tzewjweuxc0pskvArTI2Oo070h65GpoIKLc9jf+UA69cRtquwP93aZKtW06U8dQJAF2Y44ks/mK5+eyDqik3koCI08qaC8HYq2wVl7G2QkJ6sbAaILtcvD92ToOvyGyeE0flvmDZxMYlvaZnaQ0lcSQJBAKZU6umJi3/xeEbkJqMfeLclD27XGEFoPeNrmdx0q10Azp4NfJAY+Z8KRyQCR2BEG+oNitBOZ+YXF9KCpH3cdmECQHEigJhYg+ykOvr1aiZUMFT72HU0jnmQe2FVekuG+LJUt2Tm7GtMjTFoGpf0JwrVuZN39fOYAlo+nTixgeW7X8Y=",
+    "publicKey": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB",
+    "requiredCredentials": [
+        "password"
+    ],
+    "users": [
+        {
+            "username": "alice",
+            "enabled": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "alice"
+                }
+            ],
+            "realmRoles": [
+                "user"
+            ]
+        },
+        {
+            "username": "jdoe",
+            "enabled": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "jdoe"
+                }
+            ],
+            "realmRoles": [
+                "user",
+                "user-premium"
+            ]
+        },
+        {
+            "username": "service-account-app-authz-rest-springboot",
+            "enabled": true,
+            "serviceAccountClientId": "app-authz-rest-springboot",
+            "clientRoles": {
+                "app-authz-rest-springboot": [
+                    "uma_protection"
+                ]
+            }
+        }
+    ],
+    "roles": {
+        "realm": [
+            {
+                "name": "user",
+                "description": "User privileges"
+            },
+            {
+                "name": "user-premium",
+                "description": "User premium privileges"
+            }
+        ]
+    },
+    "clients": [
+        {
+            "clientId": "app-authz-rest-springboot",
+            "enabled": true,
+            "baseUrl": "http://localhost:8080",
+            "adminUrl": "http://localhost:8080",
+            "redirectUris": [
+                "http://localhost:8080/*"
+            ],
+            "secret": "secret",
+            "directAccessGrantsEnabled": true,
+            "authorizationServicesEnabled": true,
+            "authorizationSettings": {
+                "allowRemoteResourceManagement": false,
+                "policyEnforcementMode": "ENFORCING",
+                "resources": [
+                    {
+                        "name": "Default Resource",
+                        "uri": "/api/{resource}"
+                    },
+                    {
+                        "name": "Premium Resource",
+                        "uri": "/api/premium"
+                    }
+                ],
+                "policies": [
+                    {
+                        "name": "Only Premium User Policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"user-premium\",\"required\":false}]"
+                        }
+                    },
+                    {
+                        "name": "Only User Policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"user\",\"required\":false}]"
+                        }
+                    },
+                    {
+                        "name": "Default Resource Permission",
+                        "description": "A permission that applies to the default resource",
+                        "type": "resource",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"Default Resource\"]",
+                            "applyPolicies": "[\"Only User Policy\"]"
+                        }
+                    },
+                    {
+                        "name": "Premium Resource Permission",
+                        "type": "resource",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"Premium Resource\"]",
+                            "applyPolicies": "[\"Only Premium User Policy\"]"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/app-authz-springboot/config/quickstart-realm.json
+++ b/app-authz-springboot/config/quickstart-realm.json
@@ -137,17 +137,6 @@
                         }
                     },
                     {
-                        "name": "Default Permission",
-                        "description": "A permission that applies to the default resource type",
-                        "type": "resource",
-                        "logic": "POSITIVE",
-                        "decisionStrategy": "UNANIMOUS",
-                        "config": {
-                            "defaultResourceType": "urn:app-authz-springboot:resources:default",
-                            "applyPolicies": "[\"Default Policy\"]"
-                        }
-                    },
-                    {
                         "name": "Default Resource Permission",
                         "type": "resource",
                         "logic": "POSITIVE",

--- a/app-authz-springboot/src/test/resources/quickstart-realm.json
+++ b/app-authz-springboot/src/test/resources/quickstart-realm.json
@@ -137,17 +137,6 @@
                         }
                     },
                     {
-                        "name": "Default Permission",
-                        "description": "A permission that applies to the default resource type",
-                        "type": "resource",
-                        "logic": "POSITIVE",
-                        "decisionStrategy": "UNANIMOUS",
-                        "config": {
-                            "defaultResourceType": "urn:app-authz-springboot:resources:default",
-                            "applyPolicies": "[\"Default Policy\"]"
-                        }
-                    },
-                    {
                         "name": "Default Resource Permission",
                         "type": "resource",
                         "logic": "POSITIVE",

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -20,6 +20,7 @@ fi
 
 if [ $1 == "group4" ]; then
   cd app-authz-springboot && mvn -B -s ../maven-settings.xml clean test
+  cd app-authz-rest-springboot && mvn -B -s ../maven-settings.xml clean test
   cd ../service-springboot-rest && mvn -B -s ../maven-settings.xml clean test
   mvn spring-boot:run&
   cd ../app-springboot

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -3,13 +3,15 @@
 if [ $1 == "group1" ]; then
   for i in `mvn -q --also-make exec:exec -Dexec.executable="pwd" | awk -F '/' '{if (NR > 1) print $NF}'`;
   do
-    mvn -s maven-settings.xml clean install -Pwildfly-managed -Denforcer.skip=true -f $i
+    # FIXME Workaround to skip Angular.js app on Travis CI while we figure out the best way to fix the issues with Selenium
+    if [ "$i" = "app-angular2" ]; then
+      continue
+    fi
+    mvn -B -s maven-settings.xml clean install -Pwildfly-managed -Denforcer.skip=true -f $i
   done
 fi
 
 if [ $1 == "group2" ]; then
-  mvn -B -s maven-settings.xml test -Pkeycloak-remote -f user-storage-jpa
-  mvn -B -s maven-settings.xml test -Pkeycloak-remote -f user-storage-simple
   mvn -B -s maven-settings.xml test -Pwildfly-managed -f action-token-authenticator </dev/null
   mvn -B -s maven-settings.xml test -Pwildfly-managed -f action-token-required-action </dev/null
 fi
@@ -27,4 +29,8 @@ if [ $1 == "group4" ]; then
   mvn -B -s ../maven-settings.xml clean test
 fi
 
+if [ $1 == "group5" ]; then
+  mvn -B -s maven-settings.xml test -Pkeycloak-remote -f user-storage-jpa
+  mvn -B -s maven-settings.xml test -Pkeycloak-remote -f user-storage-simple
+fi
 

--- a/user-storage-jpa/src/test/java/org/keycloak/quickstart/ArquillianJpaStorageTest.java
+++ b/user-storage-jpa/src/test/java/org/keycloak/quickstart/ArquillianJpaStorageTest.java
@@ -108,7 +108,7 @@ public class ArquillianJpaStorageTest {
     }
 
     private void waitTillElementPresent(By locator) {
-        Graphene.waitGui().withTimeout(30, TimeUnit.SECONDS).until(ExpectedConditions.visibilityOfAllElementsLocatedBy(locator));
+        Graphene.waitGui().withTimeout(60, TimeUnit.SECONDS).until(ExpectedConditions.visibilityOfAllElementsLocatedBy(locator));
     }
     
     private void navigateTo(String path) {

--- a/user-storage-simple/src/test/java/org/keycloak/quickstart/ArquillianSimpleStorageTest.java
+++ b/user-storage-simple/src/test/java/org/keycloak/quickstart/ArquillianSimpleStorageTest.java
@@ -88,7 +88,7 @@ public class ArquillianSimpleStorageTest {
     }
 
     private void navigateTo(String path) {
-        webDriver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
+        webDriver.manage().timeouts().pageLoadTimeout(60, TimeUnit.SECONDS);
         webDriver.navigate().to(format(KEYCLOAK_URL,
                 contextRoot.getHost(), contextRoot.getPort(), path));
     }


### PR DESCRIPTION
This is pretty much a rebase of @pedroigor's PR + my changes for Travis CI to ignore Angular.js example.

See: https://github.com/keycloak/keycloak-quickstarts/pull/48