### PR TITLE
Fixing URLs to point to Keycloak, not Widfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To start the <span>Keycloak</span> server on a separate host:
    For Windows: KEYCLOAK_HOME\bin\standalone.bat -b 0.0.0.0
    ````
 
-3. The URL of the <span>Keycloak</span> server will be http://&lt;HOSTNAME&gt;:8080 (replace &lt;HOSTNAME&gt; with the hostname of the separate host).
+3. The URL of the <span>Keycloak</span> server will be http://&lt;HOSTNAME&gt;:8080/auth/ (replace &lt;HOSTNAME&gt; with the hostname of the separate host).
 
 To start the <span>Keycloak</span> server on different ports:
 
@@ -66,11 +66,11 @@ To start the <span>Keycloak</span> server on different ports:
    For Windows: KEYCLOAK_HOME\bin\standalone.bat -Djboss.socket.binding.port-offset=100
    ````
 
-3. The URL of the <span>Keycloak</span> server will be *http://localhost:8180*
+3. The URL of the <span>Keycloak</span> server will be *http://localhost:8180/auth/*
 
 ### <a id="add-admin"></a>Add Admin User
 
-Open the main page for the <span>Keycloak</span> server ([localhost:8180](http://localhost:8180) or http://&lt;HOSTNAME&gt;:8080). If
+Open the main page for the <span>Keycloak</span> server ([localhost:8080/auth/](http://localhost:8080/auth/) or http://&lt;HOSTNAME&gt;:8080/auth/). If
 this is a new installation of <span>Keycloak</span> server you will be instructed to create an initial admin user. To continue with
 the quickstarts you need to do this prior to continuing.
 

--- a/action-token-authenticator/pom.xml
+++ b/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
     </parent>
 
     <name>Quickstart: Action Token With Authenticator</name>

--- a/action-token-required-action/pom.xml
+++ b/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
     </parent>
 
     <name>Quickstart: Action Token With Required Action</name>

--- a/app-angular2/pom.xml
+++ b/app-angular2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-servlet/pom.xml
+++ b/app-authz-jee-servlet/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-vanilla/pom.xml
+++ b/app-authz-jee-vanilla/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-springboot/pom.xml
+++ b/app-authz-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-authz-policy/pom.xml
+++ b/app-authz-uma-photoz/photoz-authz-policy/pom.xml
@@ -20,7 +20,7 @@
     <!--parent-->
         <groupId>org.keycloak.quickstarts</groupId>
         <!--artifactId>app-authz-uma-photoz-parent</artifactId-->
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <!--relativePath>../pom.xml</relativePath>
     </parent-->
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-uma-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-uma-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-restful-api</artifactId>

--- a/app-authz-uma-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-testsuite</artifactId>

--- a/app-authz-uma-photoz/pom.xml
+++ b/app-authz-uma-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-html5/pom.xml
+++ b/app-jee-html5/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-html5/pom.xml
+++ b/app-profile-jee-html5/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-vanilla/pom.xml
+++ b/app-profile-jee-vanilla/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-saml-jee-jsp/pom.xml
+++ b/app-profile-saml-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-springboot/pom.xml
+++ b/app-springboot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/fuse/app-war/pom.xml
+++ b/fuse/app-war/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <artifactId>keycloak-fuse-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>keycloak-fuse-app-war-jsp</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>war</packaging>
     <name>Keycloak Quickstart: WAR frontend application</name>
     <description>JBoss Fuse WAR frontend application secured by Keycloak</description>

--- a/fuse/features/pom.xml
+++ b/fuse/features/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-fuse-features</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: Fuse Features</name>
     <description>JBoss Fuse features to simplify install all Keycloak Fuse quickstarts</description>

--- a/fuse/pom.xml
+++ b/fuse/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse-parent</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>pom</packaging>
     <properties>
         <camel.version>2.17.0</camel.version>

--- a/fuse/server/pom.xml
+++ b/fuse/server/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-fuse-server</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: JBoss Fuse Server</name>
     <description>Quickstart JBoss Fuse Server</description>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.keycloak.quickstarts</groupId>
             <artifactId>keycloak-fuse-features</artifactId>
-            <version>4.0.0.Beta2-SNAPSHOT</version>
+            <version>4.0.0.Beta2</version>
         </dependency>
     </dependencies>
 

--- a/fuse/service-camel/pom.xml
+++ b/fuse/service-camel/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <artifactId>keycloak-fuse-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse-service-camel</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>bundle</packaging>
     <name>Keycloak Quickstart: JBoss Fuse Service - Camel</name>
     <description>JBoss Fuse Apache Camel Service secured by Keycloak</description>

--- a/fuse/service-cxf-jaxrs/pom.xml
+++ b/fuse/service-cxf-jaxrs/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <artifactId>keycloak-fuse-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-service-cxf-jaxrs</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>bundle</packaging>
     <name>Keycloak Quickstart: JBoss Fuse Service - CXF JAXRS</name>
     <description>JBoss Fuse Apache CXF JAXRS Service Secured by Keycloak</description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>4.0.0.Beta2-SNAPSHOT</version>
+    <version>4.0.0.Beta2</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-springboot-rest/pom.xml
+++ b/service-springboot-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-simple/pom.xml
+++ b/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.0.0.Beta2-SNAPSHOT</version>
+        <version>4.0.0.Beta2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The Keycloak is available under /auth, not at root. The links were pointing to Wildfly console, instead of Keycloak.