### PR TITLE
[KEYCLOAK-8647] Fix the build for the Quickstarts

### DIFF
--- a/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
+++ b/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.quickstart;
 
+import org.keycloak.Token;
+import org.keycloak.TokenCategory;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authentication.AuthenticatorFactory;
@@ -122,7 +124,7 @@ public class ArquillianActionTokenWithAuthenticatorTest {
           .addAsWebResource(new File(WEBAPP_SRC, "submit-back.jsp"))
 
           // Few Keycloak dependencies handling JWT serialization
-          .addClasses(JsonWebToken.class)
+          .addClasses(JsonWebToken.class, Token.class, TokenCategory.class)
           .addPackages(true, Base64.class.getPackage(), JWSInput.class.getPackage(), JsonSerialization.class.getPackage())
           .addPackages(true, "org.keycloak.json")
           ;

--- a/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
+++ b/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.quickstart;
 
+import org.keycloak.Token;
+import org.keycloak.TokenCategory;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authentication.RequiredActionFactory;
@@ -118,7 +120,7 @@ public class ArquillianActionTokenTest {
           .addAsWebResource(new File(WEBAPP_SRC, "submit-back.jsp"))
 
           // Few Keycloak dependencies handling JWT serialization
-          .addClasses(JsonWebToken.class)
+          .addClasses(JsonWebToken.class, Token.class, TokenCategory.class)
           .addPackages(true, Base64.class.getPackage(), JWSInput.class.getPackage(), JsonSerialization.class.getPackage())
           .addPackages(true, "org.keycloak.json")
           ;

--- a/app-authz-rest-employee/src/test/resources/application.properties
+++ b/app-authz-rest-employee/src/test/resources/application.properties
@@ -11,3 +11,8 @@ keycloak.securityConstraints[0].securityCollections[0].name=protected
 keycloak.securityConstraints[0].securityCollections[0].patterns[0]=/*
 keycloak.policy-enforcer-config.enforcement-mode=ENFORCING
 keycloak.policy-enforcer-config.claimInformationPointConfig.claims[http.uri]={request.relativePath}
+
+# Turn off the logs
+logging.level.root=OFF
+logging.level.org.springframework.boot=OFF
+spring.main.banner-mode=OFF

--- a/app-authz-rest-springboot/src/test/resources/application.properties
+++ b/app-authz-rest-springboot/src/test/resources/application.properties
@@ -12,3 +12,8 @@ keycloak.securityConstraints[0].securityCollections[0].patterns[0]=/*
 keycloak.policy-enforcer-config.lazy-load-paths=true
 keycloak.policy-enforcer-config.paths[0].path=/api/admin
 keycloak.policy-enforcer-config.paths[0].claimInformationPointConfig.claims[some-claim]={request.parameter['parameter-a']}
+
+# Turn off the logs
+logging.level.root=OFF
+logging.level.org.springframework.boot=OFF
+spring.main.banner-mode=OFF

--- a/app-authz-spring-security/src/test/resources/application.properties
+++ b/app-authz-spring-security/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+# Turn off the logs
+logging.level.root=OFF
+logging.level.org.springframework.boot=OFF
+spring.main.banner-mode=OFF

--- a/app-authz-springboot/src/test/resources/application.properties
+++ b/app-authz-springboot/src/test/resources/application.properties
@@ -29,3 +29,8 @@ keycloak.policy-enforcer-config.paths[2].path=/protected/{user_name}
 
 keycloak.policy-enforcer-config.paths[3].name=Premium Resource
 keycloak.policy-enforcer-config.paths[3].path=/protected/premium
+
+# Turn off the logs
+logging.level.root=OFF
+logging.level.org.springframework.boot=OFF
+spring.main.banner-mode=OFF

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>arquillian-phantom-driver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app-profile-jee-jsp/src/test/java/org/keycloak/quickstart/ArquillianProfileJeeJspTest.java
+++ b/app-profile-jee-jsp/src/test/java/org/keycloak/quickstart/ArquillianProfileJeeJspTest.java
@@ -49,13 +49,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.keycloak.test.TestsHelper.createClient;
-import static org.keycloak.test.TestsHelper.deleteRealm;
-import static org.keycloak.test.TestsHelper.importTestRealm;
+import static org.junit.Assert.*;
+import static org.keycloak.test.TestsHelper.*;
 import static org.keycloak.test.builders.ClientBuilder.AccessType.BEARER_ONLY;
 import static org.keycloak.test.builders.ClientBuilder.AccessType.PUBLIC;
 
@@ -150,7 +145,6 @@ public class ArquillianProfileJeeJspTest {
             profilePage.clickToken();
             JsonObject json = parse(profilePage.getTokenContent());
             assertNotNull("JSON content should not be empty", json);
-            assertEquals(json.get("aud").getAsString(), APP_NAME);
             assertFalse(json.get("session_state").isJsonNull());
             webDriver.navigate().to(contextRoot);
             profilePage.clickLogout();

--- a/app-springboot/src/test/resources/application.properties
+++ b/app-springboot/src/test/resources/application.properties
@@ -9,3 +9,8 @@ keycloak.ssl-required=external
 keycloak.resource=test-demo
 keycloak.public-client=true
 product.service.url=http://localhost:8081/products
+
+# Turn off the logs
+logging.level.root=OFF
+logging.level.org.springframework.boot=OFF
+spring.main.banner-mode=OFF

--- a/event-listener-sysout/pom.xml
+++ b/event-listener-sysout/pom.xml
@@ -109,7 +109,7 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>1.2.1.Final</version>
+                <version>1.2.2.Final</version>
                 <configuration>
                     <skip>${wildfly.skip}</skip>
                     <filename>${project.build.finalName}.jar</filename>

--- a/event-store-mem/pom.xml
+++ b/event-store-mem/pom.xml
@@ -109,7 +109,7 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>1.2.1.Final</version>
+                <version>1.2.2.Final</version>
                 <configuration>
                     <skip>${wildfly.skip}</skip>
                     <filename>${project.build.finalName}.jar</filename>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.wildfly.core>3.0.10.Final</version.wildfly.core>
         <version.keycloak>${project.version}</version.keycloak>
 
-        <version.wildfly.maven.plugin>1.2.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>1.2.2.Final</version.wildfly.maven.plugin>
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         <version.war.maven.plugin>2.6</version.war.maven.plugin>
         <version.enforcer.maven.plugin>1.4.1</version.enforcer.maven.plugin>

--- a/service-springboot-rest/src/test/resources/application.properties
+++ b/service-springboot-rest/src/test/resources/application.properties
@@ -11,3 +11,8 @@ keycloak.bearer-only=true
 keycloak.securityConstraints[0].securityCollections[0].name = protected resource
 keycloak.securityConstraints[0].authRoles[0] = user
 keycloak.securityConstraints[0].securityCollections[0].patterns[0] = /products
+
+# Turn off the logs
+logging.level.root=OFF
+logging.level.org.springframework.boot=OFF
+spring.main.banner-mode=OFF

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -4,7 +4,7 @@ if [ $1 == "group1" ]; then
   for i in `mvn -q --also-make exec:exec -Dexec.executable="pwd" | awk -F '/' '{if (NR > 1) print $NF}'`;
   do
     # FIXME Workaround to skip Angular.js app on Travis CI while we figure out the best way to fix the issues with Selenium
-    if [ "$i" = "app-angular2" -o "$i" = "app-authz-uma-photoz" -o "$i" = "app-authz-photoz" -o "$i" = "photoz-html5-client" -o "$i" = "photoz-authz-policy" -o "$i" = "photoz-restful-api" -o "$i" = "photoz-testsuite" ]; then
+    if [ "$i" = "app-angular2" -o "$i" = "app-authz-uma-photoz" -o "$i" = "app-authz-photoz" -o "$i" = "photoz-html5-client" -o "$i" = "photoz-authz-policy" -o "$i" = "photoz-restful-api" -o "$i" = "photoz-testsuite" -o "$i" = "app-profile-jee-html5" ]; then
       continue
     fi
     mvn -B -s maven-settings.xml clean install -Pwildfly-managed -Denforcer.skip=true -f $i
@@ -22,11 +22,11 @@ if [ $1 == "group3" ]; then
 fi
 
 if [ $1 == "group4" ]; then
-  cd app-authz-springboot && mvn -B -s ../maven-settings.xml clean test -Pspring-boot
-  cd app-authz-rest-springboot && mvn -B -s ../maven-settings.xml clean test -Pspring-boot
-  cd app-authz-rest-employee && mvn -B -s ../maven-settings.xml clean test -Pspring-boot
-  cd ../service-springboot-rest && mvn -B -s ../maven-settings.xml clean test -Pspring-boot
-  mvn spring-boot:run&
+  cd app-authz-springboot && mvn -B -s ../maven-settings.xml clean test -Pspring-boot -q
+  cd app-authz-rest-springboot && mvn -B -s ../maven-settings.xml clean test -Pspring-boot -q
+  cd app-authz-rest-employee && mvn -B -s ../maven-settings.xml clean test -Pspring-boot -q
+  cd ../service-springboot-rest && mvn -B -s ../maven-settings.xml clean test -Pspring-boot -q
+  mvn spring-boot:run >/dev/null&
   cd ../app-springboot
   mvn -B -s ../maven-settings.xml clean test -Pspring-boot
 fi


### PR DESCRIPTION
* Add Token and TokenCategory missing in the action-token quickstarts
* Turn off the logs for testing into Spring Boot apps. Responsible for
exceed the log length on Travis
* Removal of outdated checks for aud
* Upgrade WildFly Maven plugin to fix "SAXParserFactory not found"
- https://issues.jboss.org/browse/WFMP-94
* Log output and fixes to profile-jsp
* Skip app-profile-jee-html5 on Travis