### PR TITLE
Correct error of quickstart example user-storage-jpa

### DIFF
--- a/action-token-authenticator/pom.xml
+++ b/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
     </parent>
 
     <name>Quickstart: Action Token With Authenticator</name>

--- a/action-token-required-action/pom.xml
+++ b/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
     </parent>
 
     <name>Quickstart: Action Token With Required Action</name>

--- a/app-angular2/pom.xml
+++ b/app-angular2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-servlet/pom.xml
+++ b/app-authz-jee-servlet/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-vanilla/pom.xml
+++ b/app-authz-jee-vanilla/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-restful-api</artifactId>

--- a/app-authz-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-testsuite</artifactId>

--- a/app-authz-photoz/pom.xml
+++ b/app-authz-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-rest-employee/pom.xml
+++ b/app-authz-rest-employee/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-spring-security/pom.xml
+++ b/app-authz-spring-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot/pom.xml
+++ b/app-authz-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-uma-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-uma-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-restful-api</artifactId>

--- a/app-authz-uma-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-testsuite</artifactId>

--- a/app-authz-uma-photoz/pom.xml
+++ b/app-authz-uma-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-html5/pom.xml
+++ b/app-jee-html5/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-html5/pom.xml
+++ b/app-profile-jee-html5/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-vanilla/pom.xml
+++ b/app-profile-jee-vanilla/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-saml-jee-jsp/pom.xml
+++ b/app-profile-saml-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-springboot/pom.xml
+++ b/app-springboot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/event-listener-sysout/pom.xml
+++ b/event-listener-sysout/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Listener System.out</name>

--- a/event-store-mem/pom.xml
+++ b/event-store-mem/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Store In-Mem</name>

--- a/fuse63/app-war/pom.xml
+++ b/fuse63/app-war/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <artifactId>keycloak-fuse63-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>keycloak-fuse63-app-war-jsp</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>war</packaging>
     <name>Keycloak Quickstart: Fuse 6.3 WAR frontend application</name>
     <description>JBoss Fuse 6.3 WAR frontend application secured by Keycloak</description>

--- a/fuse63/features/pom.xml
+++ b/fuse63/features/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>keycloak-fuse63-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -27,7 +27,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-fuse63-features</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: Fuse 6.3 Features</name>
     <description>JBoss Fuse 6.3 features to simplify install all Keycloak Fuse quickstarts</description>

--- a/fuse63/pom.xml
+++ b/fuse63/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse63-parent</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <properties>
         <camel.version>2.17.0</camel.version>

--- a/fuse63/server/pom.xml
+++ b/fuse63/server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-fuse63-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-fuse63-server</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: JBoss Fuse 6.3 Server</name>
     <description>Quickstart JBoss Fuse 6.3 Server</description>

--- a/fuse63/service-camel/pom.xml
+++ b/fuse63/service-camel/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <artifactId>keycloak-fuse63-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse63-service-camel</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>bundle</packaging>
     <name>Keycloak Quickstart: JBoss Fuse 6.3 Service - Camel</name>
     <description>JBoss Fuse Apache Camel 6.3 Service secured by Keycloak</description>

--- a/fuse63/service-cxf-jaxrs/pom.xml
+++ b/fuse63/service-cxf-jaxrs/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <artifactId>keycloak-fuse63-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse63-service-cxf-jaxrs</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>bundle</packaging>
     <name>Keycloak Quickstart: JBoss Fuse 6.3 Service - CXF JAXRS</name>
     <description>JBoss Fuse 6.3 Apache CXF JAXRS Service Secured by Keycloak</description>

--- a/fuse70/app-war/pom.xml
+++ b/fuse70/app-war/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <artifactId>keycloak-fuse70-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>keycloak-fuse70-app-war-jsp</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>war</packaging>
     <name>Keycloak Quickstart: Fuse 7.0 WAR frontend application</name>
     <description>JBoss Fuse 7.0 WAR frontend application secured by Keycloak</description>

--- a/fuse70/features/pom.xml
+++ b/fuse70/features/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>keycloak-fuse70-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -27,7 +27,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-fuse70-features</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: Fuse 7.0 Features</name>
     <description>JBoss Fuse 7.0 features to simplify install all Keycloak Fuse quickstarts</description>

--- a/fuse70/pom.xml
+++ b/fuse70/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse70-parent</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <properties>
         <camel.version>2.17.0</camel.version>

--- a/fuse70/server/pom.xml
+++ b/fuse70/server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-fuse70-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-fuse70-server</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: JBoss Fuse 7.0 Server</name>
     <description>Quickstart JBoss Fuse 7.0 Server</description>

--- a/fuse70/service-camel/pom.xml
+++ b/fuse70/service-camel/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <artifactId>keycloak-fuse70-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse70-service-camel</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>bundle</packaging>
     <name>Keycloak Quickstart: JBoss Fuse 7.0 Service - Camel</name>
     <description>JBoss Fuse Apache Camel 7.0 Service secured by Keycloak</description>

--- a/fuse70/service-cxf-jaxrs/pom.xml
+++ b/fuse70/service-cxf-jaxrs/pom.xml
@@ -19,14 +19,14 @@
     <parent>
         <artifactId>keycloak-fuse70-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-fuse70-service-cxf-jaxrs</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>bundle</packaging>
     <name>Keycloak Quickstart: JBoss Fuse 7.0 Service - CXF JAXRS</name>
     <description>JBoss Fuse 7.0 Apache CXF JAXRS Service Secured by Keycloak</description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>4.6.0.Final-SNAPSHOT</version>
+    <version>4.6.0.Final</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-springboot-rest/pom.xml
+++ b/service-springboot-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -140,7 +140,7 @@
                                     <goal>add-resource</goal>
                                 </goals>
                                 <configuration>
-                                    <port>9990</port>
+                                    <port>10090</port>
                                     <force/>
                                     <address>subsystem=datasources</address>
                                     <resources>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -140,7 +140,7 @@
                                     <goal>add-resource</goal>
                                 </goals>
                                 <configuration>
-                                    <port>10090</port>
+                                    <port>9990</port>
                                     <force/>
                                     <address>subsystem=datasources</address>
                                     <resources>

--- a/user-storage-jpa/src/main/resources/META-INF/persistence.xml
+++ b/user-storage-jpa/src/main/resources/META-INF/persistence.xml
@@ -5,7 +5,7 @@
         http://java.sun.com/xml/ns/persistence
         http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
     <persistence-unit name="user-storage-jpa-example">
-        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <jta-data-source>java:jboss/datasources/ExampleXADS</jta-data-source>
 
         <class>org.keycloak.quickstart.storage.user.UserEntity</class>
 

--- a/user-storage-simple/pom.xml
+++ b/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>4.6.0.Final-SNAPSHOT</version>
+        <version>4.6.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Example wont work because the jta-datasource config in the persistence.xml did not reference the XA datasource defined in the pom.xml. It was possible though to deploy the user storage to the Keycloak instance and to load it. But when creating a user you would see the error that the JDBC Connection could not be established.
