### PR TITLE
[KEYCLOAK-8917] Prepare QuickStarts for RH-SSO 7.3

### DIFF
--- a/app-authz-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-photoz/photoz-restful-api/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-authz-client</artifactId>
-            <version>${project.version}</version>
+            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/app-authz-uma-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-uma-photoz/photoz-restful-api/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-authz-client</artifactId>
-            <version>${project.version}</version>
+            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -102,20 +102,21 @@
             <dependency>
                 <groupId>org.keycloak.bom</groupId>
                 <artifactId>keycloak-adapter-bom</artifactId>
-                <version>${version.keycloak}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-test-helper</artifactId>
-                <version>${version.keycloak}</version>
-                <scope>test</scope>
+                <groupId>org.keycloak.bom</groupId>
+                <artifactId>keycloak-misc-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.keycloak.bom</groupId>
                 <artifactId>keycloak-spi-bom</artifactId>
-                <version>${version.keycloak}</version>
+                <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This change prepare the quickstarts to the changes present in Keycloak
4.7.0.Final and 4.8.0.Final.

One important thing to notice is the fact that this change depends the
changes merged
[here](https://github.com/keycloak/keycloak/commit/abd4e5dd3b129a45d953d483ed89697442fa5ead).

## Building instructions

1. git clone -b productize-poc https://github.com/abstractj/keycloak.git && cd keycloak && mvn clean install -DskipTests -Pdistribution 
2. git clone -b productize-poc https://github.com/abstractj/redhat-sso-boms.git && cd redhat-sso-boms && mvn clean install
3. Run the productize.sh script