### PR TITLE
Remove deprecated install command from service-nodejs's package.json

### DIFF
--- a/service-nodejs/README.md
+++ b/service-nodejs/README.md
@@ -64,11 +64,11 @@ Build and Deploy the Quickstart
 
 1. Open a terminal and navigate to the root directory of this quickstart.
 
-2. The following shows the command to run the quickstart:
+2. The following shows the commands to run the quickstart:
 
    ````
-   npm install
-   node app
+   npm install # install dependencies
+   npm start # start the app
    ````
 
 Access the Quickstart

--- a/service-nodejs/package.json
+++ b/service-nodejs/package.json
@@ -2,8 +2,7 @@
   "name" : "service-nodejs",
   "version" : "0.0.1",
   "scripts" : {
-    "start" : "node app.js",
-    "install" : "nsp check"
+    "start" : "node app.js"
   },
   "dependencies" : {
     "keycloak-connect": "keycloak/keycloak-nodejs-connect",


### PR DESCRIPTION
The ```service-nodejs``` example can't be installed because of the deprecated install script ```nsp check``` .

Removing it from the ```package.json``` does the job.
Also updated the running instructions.