### PR TITLE
KEYCLOAK-12676 Shell script from the Quickstarts return an empty vers…

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export VERSION=`curl -s https://repo1.maven.org/maven2/org/keycloak/keycloak-server-dist/ | sed -e 's/<[^>]*>//g' | grep -i final | cut -d '/' -f1 | tail -n1`
+export VERSION=$(curl -s https://repo1.maven.org/maven2/org/keycloak/keycloak-server-dist/ | sed -e 's/<[^>]*>//g' | grep -e '[0-9]\{1,2\}\.[0-9]\.[0-9]/' | cut -d '/' -f1 | tail -n1)
 export KEYCLOAK="keycloak-${VERSION}"


### PR DESCRIPTION
…ion of Keycloak

@abstractj This version of the command checks for one or two major numbers of the version in the list for future xy.x.x Keycloak releases (eg 10.0.0) followed by "/" slash char eliminating the ".Final" string from the previous releases.
