### PR TITLE
KEYCLOAK-13900 Wrong port in user-storage-jpa quickstart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 
 install:
   - travis_wait 20 mvn -s maven-settings.xml clean install --no-snapshot-updates -B -V -q
-  - mvn -s maven-settings.xml -Padd-datasource install -f user-storage-jpa -q
+  - mvn -s maven-settings.xml -Padd-datasource install -Djboss.server.port=10090 -f user-storage-jpa -q
 
 before_script:
   - export MAVEN_SKIP_RC=true

--- a/user-storage-jpa/README.md
+++ b/user-storage-jpa/README.md
@@ -36,6 +36,14 @@ Start up the <span>Keycloak</span> server.  Then in the directory of this exampl
    mvn -Padd-datasource install
    ````
 
+**Note**: If the server runs on different port than `9990`, you have to specify it by setting a
+maven property `jboss.server.port` (f.e. if you've specified the `-Djboss.socket.binding.port-offset=100` 
+before starting of the server, then you should use port `10090`).
+
+   ````
+   mvn -Padd-datasource install -Djboss.server.port=10090
+   ````
+
 You only need to execute this maven command once.  If you execute this again, then you will get an error message that the datasource
 already exists.
 
@@ -48,9 +56,9 @@ added or changes you've made to users loaded by this provider will be wiped clea
 
 To deploy the provider, run the following maven command:
 
-    ````
-    mvn clean install wildfly:deploy
-    ````
+   ````
+   mvn clean install wildfly:deploy
+   ````
 
 If you want to play with and modify the example, simply rerun the maven deploy command above and the new version will be hot deployed.
 

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -41,6 +41,7 @@
         <version.compiler.maven.plugin>3.5.1</version.compiler.maven.plugin>
         <version.hibernate.javax.persistence>1.0.0.Final</version.hibernate.javax.persistence>
         <version.jboss-ejb-api>1.0.0.Final</version.jboss-ejb-api>
+        <jboss.server.port>9990</jboss.server.port>
     </properties>
 
     <dependencies>
@@ -140,7 +141,7 @@
                                     <goal>add-resource</goal>
                                 </goals>
                                 <configuration>
-                                    <port>10090</port>
+                                    <port>${jboss.server.port}</port>
                                     <force/>
                                     <address>subsystem=datasources</address>
                                     <resources>

--- a/user-storage-jpa/src/main/resources/META-INF/persistence.xml
+++ b/user-storage-jpa/src/main/resources/META-INF/persistence.xml
@@ -5,7 +5,7 @@
         http://java.sun.com/xml/ns/persistence
         http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
     <persistence-unit name="user-storage-jpa-example">
-        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <jta-data-source>java:jboss/datasources/ExampleXADS</jta-data-source>
 
         <class>org.keycloak.quickstart.storage.user.UserEntity</class>
 


### PR DESCRIPTION
JIRA: [KEYCLOAK-13900](https://issues.redhat.com/browse/KEYCLOAK-13900)

AFAIK the _ExampleXADS_ is registered, when the user add datasource by maven profile `add-datasource`. This datasource is related only for this QS, because it has to be a `xa datasource` and _KeycloakDS_ is default `non-xa DS` and _ExampleDS_ is `non-xa` too.
