### PR TITLE
KEYCLOAK-16487 KEYCLOAK-16505 Fix photoz QS

### DIFF
--- a/app-authz-photoz/README.md
+++ b/app-authz-photoz/README.md
@@ -18,7 +18,7 @@ Basically, it is a project containing three modules:
  
 * **photoz-restful-api**, a simple RESTFul API based on JAX-RS and acting as a resource server.
 * **photoz-html5-client**, a HTML5 + AngularJS client that will consume the RESTful API published by a resource server.
-* **photoz-authz-policy**, a simple project with some rule-based policies using JBoss Drools.
+* **photoz-js-policies**, a simple project with some rule-based policies using JavaScript.
 
 For this application, users can be regular users or administrators. Regular users can create/view/delete their albums 
 and administrators can do anything. Regular users are also allowed to share their albums with other users.
@@ -159,7 +159,7 @@ If everything is correct, you will be redirect to Keycloak login page. You can l
 Creating and Sharing Resources
 ----------
 
-Lest's first login as Alice (username: alice, password: alice). Once logged in, the `photoz` client app will display a simple
+Let's first login as Alice (username: alice, password: alice). Once logged in, the `photoz` client app will display a simple
 page containing some links that can be used to display things like the Access Token. While it is interesting to
 view the token contents, we will focus on the main functionality of the quickstart, which is managing albums.
 
@@ -171,24 +171,21 @@ let's crete two albums, named `Italy Vacations` and `Greece Vacations`.
 * It is also possible to delete an album by clicking on the `[X]` link next to it but we won't do it for the moment.
 
 Alice can now manage her albums and share them with other users. Click on the `My Account` link at the top of the page. You
-will be directed to the Keycloak Account page. Next, click on `My Resources`. It will show the two albums created before in
+will be directed to the Keycloak Account page. Next, click on `Resources`. It will show the two albums created before in
 a table. Let's now share the albums with John Doe (jdoe):
 
-* Click on the `Italy Vacations` album. In the `Share with others` section fill the input field with the `jdoe` username
-and click on the `Share` button. By default both the `album:view` and `album:delete` scopes are set as permissions for
-John. 
-* The table at the top of the page now displays information about the shared album: the username with which the album was
-shared with, the permissions (scopes) this username has on the resource, the time and date of the permission grant and a
-`Revoke` buttom that Alice can use at any time to revoke access to her album.
-* Click again on the `My Resources` link in the left panel. Notice how the table of resources now has a shared symbol
-in the `Italy Vacations` album along with the number `1`, indicating the album has been shared with 1 other user.
-* Now click on the `Greece Vacations` album, enter `jdoe` in the input field but before clicking `Share` make sure to remove
-the `album:delete` scope.
-* The table at the top of the page again displays information about the shared resource. Notice how only the `album:view`
-scope has been set in the `Permission` column.
+* Click on the `Share` button for the `Italy Vacations` album. In the `Username or email` field enter the `jdoe` username
+and click on the `Add` button. Click on the `Select the permissions` field and select both `album:view` and `album:delete`
+permissions from the drop-down menu. Click `Done` to confirm the changes.
+* Alice can use the kebab menu for the `Italy Vacations` album at any time to view and change the permissions
+or revoke the access completely.
+* Click the `ˬ` (arrow down) button next to `Italy Vacations` resource name to expand the box. Notice the information that
+the resource is shared with `jdoe`.
+* Now, click on the `Share` button for the `Greece Vacations` album and enter `jdoe` username again. This time, select
+only the `album:view` permission and confirm the dialog by clicking on the `Done` button.
 
-So, to summarize, Alice has shared both her albums with John, giving him full permissions on the `Italy Vacations` album
-and only the `album:view` permission on the `Greece Vacation` album.
+So, to summarize, Alice has shared both her albums with John, giving him full permissions (`album:view` and `album:delete`)
+on the `Italy Vacations` album and only the `album:view` permission on the `Greece Vacation` album.
 
 Now click on the `Back to photoz-html5-client` link at the top of the page to return to the application and then click on
 the `Sign Out` link to logout.
@@ -200,7 +197,7 @@ Now let's login as John (username: jdoe, password: jdoe). The main page now show
 he has albums that were shared with him. Clicking on the `My Profile` link will diplay John's id and zero albums.
 
 The list of albums shared with John displays two entries. John should be allowed to remove `Italy Vacations` but he should not be able to
-delete `Greece Vacation`. That is because Alice previously granted to john only scope `album:view` in this album. 
+delete `Greece Vacation`. That is because Alice previously granted to john only scope `album:view` on this album. 
 
 Viewing All Resources
 ---------
@@ -219,9 +216,11 @@ Revoking Permissions
 ---------
 
 As a final exercise let's say that Alice now doesn't trust John anymore so she wants to revoke the permissions she gave him.
-Log in as Alice (username: alice, password: alice) and go to `My Account` and then click on `My Resources`. She has now only
-one album (`Italy Vacations`) as we removed the other one as administrators. Click on the album and now the page shows the
-table of people with access to the resource. Click on the `Revoke` button to revoke the permissions granted to John.
+Log in as Alice (username: alice, password: alice) and go to `My Account` and then click on `Resources`. She has now only
+one album (`Italy Vacations`) as we removed the other one as administrators. Select `Edit` from the kebab menu for this
+resource, remove all permissions from the `Select the permissions` field and confirm the changes by clicking the "check"
+button next to that field. Finally, close the modal dialog by clicking `Done`. Alternatively, select `Unshare all` from
+the kebab menu which would revoke access from all users Alice shared the album with.
 
 Click on the `Back to photoz-html5-client` link and the logout. Log back in as John (username: jdoe, password: jdoe) and
 notice how John has not albums shared with him.
@@ -229,5 +228,11 @@ notice how John has not albums shared with him.
 Summary
 ----------
 
-This quickstart should provides a good overview of some of the core concepts of the Keycloak Authorization Services, such as
+This quickstart should provide a good overview of some of the core concepts of the Keycloak Authorization Services, such as
 user-managed access (privacy control) and resource sharing.
+
+Integration test of the Quickstart
+----------------------------------
+
+1. Make sure you have an Keycloak server running with an admin user in the `master` realm or use the provided docker image.
+2. Run `mvn install -Pwildfly-managed`. Add `-Dbrowser=chrome` to run the tests without the headless browser mode.

--- a/app-authz-photoz/photoz-restful-api/src/main/resources/photoz-restful-api-authz-service.json
+++ b/app-authz-photoz/photoz-restful-api/src/main/resources/photoz-restful-api-authz-service.json
@@ -115,7 +115,6 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "defaultResourceType": "[\"http://photoz.com/album\"]",
         "scopes": "[\"album:view\",\"album:delete\"]",
         "applyPolicies": "[\"Only Owner and Administrators Policy\"]"
       }

--- a/app-authz-photoz/photoz-restful-api/src/main/webapp/WEB-INF/keycloak.json
+++ b/app-authz-photoz/photoz-restful-api/src/main/webapp/WEB-INF/keycloak.json
@@ -1,0 +1,41 @@
+{
+  "realm": "photoz",
+  "auth-server-url": "http://localhost:8180/auth",
+  "ssl-required": "external",
+  "resource": "photoz-restful-api",
+  "bearer-only" : true,
+  "credentials": {
+    "secret": "secret"
+  },
+  "policy-enforcer": {
+    "enforcement-mode": "PERMISSIVE",
+    "paths": [
+      {
+        "name" : "Album Resource",
+        "path" : "/album/{id}",
+        "methods" : [
+          {
+            "method": "DELETE",
+            "scopes" : ["album:delete"]
+          },
+          {
+            "method": "GET",
+            "scopes" : ["album:view"]
+          }
+        ]
+      },
+      {
+        "name" : "Album Resource",
+        "path" : "/album/shares",
+        "enforcement-mode": "DISABLED"
+      },
+      {
+        "path" : "/profile"
+      },
+      {
+        "name" : "Admin Resources",
+        "path" : "/admin/*"
+      }
+    ]
+  }
+}

--- a/app-authz-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-photoz/photoz-testsuite/pom.xml
@@ -30,11 +30,7 @@
     <description>Photoz Testsuite</description>
 
     <properties>
-        <browser>firefox</browser>
-        <webdriverDownloadBinaries>true</webdriverDownloadBinaries>
-        <droneInstantiationTimeoutInSeconds>60</droneInstantiationTimeoutInSeconds>
-        <firefox_binary/>
-        <chromeDriverBinary/>
+        <browser>chromeheadless</browser>
     </properties>
 
     <dependencies>
@@ -52,10 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-phantom-driver</artifactId>
-            <version>${arquillian-phantom.version}</version>
-            <scope>test</scope>
+            <groupId>org.jboss.arquillian.graphene</groupId>
+            <artifactId>arquillian-browser-screenshooter</artifactId>
         </dependency>
     </dependencies>
 

--- a/app-authz-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/ArquillianAuthzUMATest.java
+++ b/app-authz-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/ArquillianAuthzUMATest.java
@@ -17,12 +17,7 @@
 
 package org.keycloak.quickstart.uma;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -31,18 +26,20 @@ import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.keycloak.admin.client.Config;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.token.TokenManager;
 import org.keycloak.quickstart.uma.page.PhotozPage;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
@@ -52,9 +49,19 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import static org.junit.Assert.fail;
-import static org.keycloak.test.TestsHelper.deleteRealm;
-import static org.keycloak.test.TestsHelper.importTestRealm;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Tests for the {@code Photoz} quickstart.
@@ -68,6 +75,10 @@ public class ArquillianAuthzUMATest {
     private static final String HTML_CLIENT_APP_NAME = "photoz-html5-client";
     private static final String RESTFUL_API_APP_NAME = "photoz-restful-api";
     private static final String JS_POLICIES = "photoz-js-policies";
+    private static final String DIRECT_GRANT_APP_NAME = "direct-grant";
+    private static final String SECRET = "secret";
+    private static final String VIEW_SCOPE = "album:view";
+    private static final String DELETE_SCOPE = "album:delete";
 
     public static final String TEST_REALM = "photoz";
     public static final String KEYCLOAK_URL = "http://localhost:8180/auth";
@@ -126,17 +137,20 @@ public class ArquillianAuthzUMATest {
             testHelper.importTestRealm("/quickstart-realm.json");
 
             // import the authorization configuration for the photoz-restful-api client.
-            Keycloak keycloak = Keycloak.getInstance(KEYCLOAK_URL,
-                    FluentTestsHelper.DEFAULT_ADMIN_REALM,
-                    FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
-                    FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
-                    FluentTestsHelper.DEFAULT_ADMIN_CLIENT);
+            Keycloak keycloak = testHelper.getKeycloakInstance();
             ClientsResource clients = keycloak.realms().realm(TEST_REALM).clients();
             ClientRepresentation client = clients.findByClientId(RESTFUL_API_APP_NAME).get(0);
             ResourceServerRepresentation settings = JsonSerialization.readValue(
                     new FileInputStream(new File("../photoz-restful-api/target/classes/photoz-restful-api-authz-service.json")),
                     ResourceServerRepresentation.class);
             clients.get(client.getId()).authorization().importSettings(settings);
+
+            ClientRepresentation directGrantClient = new ClientRepresentation();
+            directGrantClient.setClientId(DIRECT_GRANT_APP_NAME);
+            directGrantClient.setPublicClient(false);
+            directGrantClient.setSecret(SECRET);
+            directGrantClient.setDirectAccessGrantsEnabled(true);
+            clients.create(directGrantClient);
         } catch (Exception e) {
             throw new IllegalStateException("Could not initialize Keycloak", e);
         }
@@ -147,61 +161,90 @@ public class ArquillianAuthzUMATest {
 
     @Test
     public void testShareResource() {
+        // login as alice, create an album, and share it with jdoe.
+        photozPage.login("alice", "alice", null);
+        photozPage.createAlbum("Germany Vacations");
+        shareResource("alice", "alice", "jdoe", "Germany Vacations", VIEW_SCOPE, DELETE_SCOPE);
+        photozPage.logout();
+
+        photozPage.login("jdoe", "jdoe", null);
+        // jdoe's album list should be empty, but shared albums list shouldn't.
+        WebElement emptyAlbumsList = webDriver.findElement(By.id("resource-list-empty"));
+        Assert.assertTrue(emptyAlbumsList.isDisplayed());
+        Assert.assertEquals("You don't have any albums, yet.", emptyAlbumsList.getText());
+        WebElement emptySharedList = webDriver.findElement(By.id("share-list-empty"));
+        Assert.assertFalse(emptySharedList.isDisplayed());
+        Assert.assertTrue(webDriver.findElement(By.id("delete-share-Germany Vacations")).isDisplayed());
+        // jdoe should be able to delete alice's shared album.
+        photozPage.deleteSharedAlbum("Germany Vacations");
+        Assert.assertTrue(emptySharedList.isDisplayed());
+        photozPage.logout();
+
+        // log back in as alice and this time share the created album without granting delete permissions.
+        photozPage.login("alice", "alice", null);
+        emptyAlbumsList = webDriver.findElement(By.id("resource-list-empty"));
+        Assert.assertTrue(emptyAlbumsList.isDisplayed());
+        Assert.assertEquals("You don't have any albums, yet.", emptyAlbumsList.getText());
+        photozPage.createAlbum("Italy Vacations");
+        shareResource("alice", "alice", "jdoe", "Italy Vacations", VIEW_SCOPE);
+        photozPage.logout();
+
+        photozPage.login("jdoe", "jdoe", null);
+        // jdoe's album list should be empty, but shared albums list shouldn't.
+        emptyAlbumsList = webDriver.findElement(By.id("resource-list-empty"));
+        Assert.assertTrue(emptyAlbumsList.isDisplayed());
+        Assert.assertEquals("You don't have any albums, yet.", emptyAlbumsList.getText());
+        emptySharedList = webDriver.findElement(By.id("share-list-empty"));
+        Assert.assertFalse(emptySharedList.isDisplayed());
+        photozPage.deleteSharedAlbum("Italy Vacations", false);
+        Assert.assertTrue(photozPage.wasDenied());
+        photozPage.logout();
+
+        photozPage.login("alice", "alice", null);
+        photozPage.deleteAlbum("Italy Vacations");
+        photozPage.logout();
+    }
+
+    private void shareResource(String ownerUsername, String ownerPassword, String user, String resourceName, String... scopes) {
+        Client client = ResteasyClientBuilder.newClient();
+
+        TokenManager tokenManager = new TokenManager(
+                new Config(KEYCLOAK_URL, TEST_REALM, ownerUsername, ownerPassword, DIRECT_GRANT_APP_NAME, SECRET),
+                client
+        );
+
+        // Permissions in Account API don't have a proper public representation (don't want to depend on whole services module)
+
+        // Get resource ID
+        String jsonResponse = client
+                .target(UriBuilder.fromUri(KEYCLOAK_URL).path("realms").path(TEST_REALM).path("account/resources"))
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .header("Authorization", "Bearer " + tokenManager.getAccessTokenString())
+                .get(String.class);
+
+        String resourceId;
         try {
-            // login as alice, create an album, and share it with jdoe.
-            photozPage.login("alice", "alice", null);
-            photozPage.createAlbum("Germany Vacations");
-            photozPage.shareResource("Germany Vacations", "jdoe");
-            photozPage.logout();
-
-            photozPage.login("jdoe", "jdoe", null);
-            // jdoe's album list should be empty, but shared albums list shouldn't.
-            WebElement emptyAlbumsList = webDriver.findElement(By.id("resource-list-empty"));
-            Assert.assertTrue(emptyAlbumsList.isDisplayed());
-            Assert.assertEquals("You don't have any albums, yet.", emptyAlbumsList.getText());
-            WebElement emptySharedList = webDriver.findElement(By.id("share-list-empty"));
-            Assert.assertFalse(emptySharedList.isDisplayed());
-            Assert.assertTrue(webDriver.findElement(By.id("delete-share-Germany Vacations")).isDisplayed());
-            // jdoe should be able to delete alice's shared album.
-            photozPage.deleteSharedAlbum("Germany Vacations");
-            Assert.assertTrue(emptySharedList.isDisplayed());
-            photozPage.logout();
-
-            // log back in as alice and this time share the created album without granting delete permissions.
-            photozPage.login("alice", "alice", null);
-            emptyAlbumsList = webDriver.findElement(By.id("resource-list-empty"));
-            Assert.assertTrue(emptyAlbumsList.isDisplayed());
-            Assert.assertEquals("You don't have any albums, yet.", emptyAlbumsList.getText());
-            photozPage.createAlbum("Italy Vacations");
-            photozPage.shareResourceWithExcludedScope("Italy Vacations", "jdoe", "album:delete");
-            photozPage.logout();
-
-            photozPage.login("jdoe", "jdoe", null);
-            // jdoe's album list should be empty, but shared albums list shouldn't.
-            emptyAlbumsList = webDriver.findElement(By.id("resource-list-empty"));
-            Assert.assertTrue(emptyAlbumsList.isDisplayed());
-            Assert.assertEquals("You don't have any albums, yet.", emptyAlbumsList.getText());
-            emptySharedList = webDriver.findElement(By.id("share-list-empty"));
-            Assert.assertFalse(emptySharedList.isDisplayed());
-            photozPage.deleteSharedAlbum("Italy Vacations", false);
-            Assert.assertTrue(wasDenied());
-            photozPage.logout();
-
-            photozPage.login("alice", "alice", null);
-            photozPage.deleteAlbum("Italy Vacations");
-            photozPage.logout();
-        } catch (Exception e) {
-            debugTest(e);
-            fail("Should have been able to share resource");
+            resourceId = StreamSupport.stream(new ObjectMapper().readTree(jsonResponse).spliterator(), false)
+                    .filter(j -> resourceName.equals(j.get("name").asText()))
+                    .map(j -> j.get("_id").asText())
+                    .findFirst().get();
         }
-    }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
-    private boolean wasDenied() {
-        return webDriver.findElement(By.id("output")).getText().equals("You can not access or perform the requested operation on this resource.");
-    }
+        // Prepare new permissions
+        String scopesStr = Stream.of(scopes).collect(Collectors.joining("\",\"","[\"","\"]"));
+        String permissions = String.format("[{\"username\":\"%s\",\"scopes\":%s}]", user, scopesStr);
 
-    private void debugTest(Exception e) {
-        System.out.println(webDriver.getPageSource());
-        e.printStackTrace();
+        // PUT new permissions
+        Response response = client.target(UriBuilder.fromUri(KEYCLOAK_URL).path("realms").path(TEST_REALM).path("account/resources").path(resourceId).path("permissions"))
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .header("Authorization", "Bearer " + tokenManager.getAccessTokenString())
+                .put(Entity.json(permissions));
+
+        Assert.assertEquals(204, response.getStatus());
+
+        client.close();
     }
 }

--- a/app-authz-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/ConsentPage.java
+++ b/app-authz-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/ConsentPage.java
@@ -47,6 +47,6 @@ public class ConsentPage {
     }
 
     public boolean isCurrent() {
-        return driver.getTitle().equalsIgnoreCase("Log in to photoz");
+        return driver.getTitle().equalsIgnoreCase("Sign in to photoz");
     }
 }

--- a/app-authz-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/PhotozPage.java
+++ b/app-authz-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/PhotozPage.java
@@ -17,9 +17,6 @@
 
 package org.keycloak.quickstart.uma.page;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Assert;
@@ -28,15 +25,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.jboss.arquillian.graphene.Graphene.waitGui;
-import static org.openqa.selenium.support.ui.ExpectedConditions.javaScriptThrowsNoExceptions;
-import static org.openqa.selenium.support.ui.ExpectedConditions.not;
-import static org.openqa.selenium.support.ui.ExpectedConditions.urlToBe;
 
 /**
  * A {@code {@link Page}} representing the Photoz application.
@@ -75,13 +66,9 @@ public class PhotozPage {
     @FindBy(id = "output")
     private WebElement output;
 
-    @FindBy(id = "referrer")
-    private WebElement backToAppLink;
-
 
     public void login(final String username, final String password, final String fullName) {
         loginPage.login(username, password);
-        waitForPageToLoad();
         if (consentPage.isCurrent()) {
             consentPage.confirm();
         }
@@ -94,7 +81,6 @@ public class PhotozPage {
     public void logout() {
         waitGui().until().element(signOutLink).is().clickable();
         signOutLink.click();
-        waitForPageToLoad();
     }
 
     public void createAlbum(final String albumName) {
@@ -124,10 +110,7 @@ public class PhotozPage {
     }
 
     private void deleteAlbum(final WebElement deleteLink) {
-        waitGui().until().element(deleteLink).is().clickable();
-        deleteLink.click();
-        waitGui().until().element(deleteLink).is().not().present();
-        waitForPageToLoad();
+        deleteAlbum(deleteLink, true);
     }
 
     private void deleteAlbum(final WebElement deleteLink, boolean waitForRemoval) {
@@ -135,128 +118,17 @@ public class PhotozPage {
         deleteLink.click();
         if (waitForRemoval) {
             waitGui().until().element(deleteLink).is().not().present();
-            waitForPageToLoad();
         }
     }
 
-    public void requestEntitlements() {
-        waitGui().until().element(requestEntitlementsLink).is().clickable();
-        requestEntitlementsLink.click();
-        waitGui().until().element(output).text().not().equalTo("");
-    }
-
-    public void shareResource(String resource, String user) {
-        goToAccountMyResource(resource);
-        WebElement userIdInput = webDriver.findElement(By.id("user_id"));
-        waitGui().until().element(userIdInput).is().present();
-        userIdInput.sendKeys(user);
-        waitGui().until().element(userIdInput).attribute("value").contains(user);
-
-        WebElement shareButton = webDriver.findElement(By.id("share-button"));
-        waitGui().until().element(shareButton).is().clickable();
-        shareButton.click();
-        waitForPageToLoad();
-        waitGui().until().element(backToAppLink).is().clickable();
-        backToAppLink.click();
-        waitForPageToLoad();
-    }
-
-    public void shareResourceWithExcludedScope(String resource, String user, String scope) {
-        goToAccountMyResource(resource);
-        WebElement userIdInput = webDriver.findElement(By.id("user_id"));
-        waitGui().until().element(userIdInput).is().present();
-        userIdInput.sendKeys(user);
-        waitGui().until().element(userIdInput).attribute("value").contains(user);
-
-        WebElement shareRemoveScope = webDriver.findElement(By.id("share-remove-scope-" + resource + "-" + scope));
-        waitGui().until().element(shareRemoveScope).is().clickable();
-        shareRemoveScope.click();
-        waitForPageToLoad();
-
-        WebElement shareButton = webDriver.findElement(By.id("share-button"));
-        waitGui().until().element(shareButton).is().clickable();
-        shareButton.click();
-        waitForPageToLoad();
-        waitGui().until().element(backToAppLink).is().clickable();
-        backToAppLink.click();
-        waitForPageToLoad();
-    }
-
-    public void requestDeleteScope(String albumName) {
-        WebElement requestDeleteAccessLink = webDriver.findElement(By.id("request-delete-share-" + albumName));
-        waitGui().until().element(requestDeleteAccessLink).is().clickable();
-        requestDeleteAccessLink.click();
-        waitGui().until().element(output).text().not().equalTo("");
-    }
-
-    public void grantRequestedPermission(String resource, String requester) {
-        goToAccountMyResources();
-        WebElement grantRemoveScope = webDriver.findElement(By.id("grant-" + resource + "-" + requester));
-        waitGui().until().element(grantRemoveScope).is().clickable();
-        grantRemoveScope.click();
-        waitForPageToLoad();
-        waitGui().until().element(backToAppLink).is().clickable();
-        backToAppLink.click();
-        waitForPageToLoad();
-    }
-
-    public void goToAccountMyResource(String name) {
-        goToAccountMyResources();
-        WebElement myResource = webDriver.findElement(By.id("detail-" + name));
-        waitGui().until().element(myResource).is().clickable();
-        myResource.click();
-        waitForPageToLoad();
-    }
-
-    public void goToAccountMyResources() {
-        gotToAccountPage();
-        WebElement myResources = webDriver.findElement(By.xpath("//a[text() = 'My Resources']"));
-        waitGui().until().element(myResources).is().clickable();
-        myResources.click();
-        waitForPageToLoad();
-    }
-
-    public void gotToAccountPage() {
-        waitGui().until().element(myAccountLink).is().clickable();
-        myAccountLink.click();
-        waitForPageToLoad();
-    }
-
-    public void waitForPageToLoad() {
-
-        if (webDriver instanceof HtmlUnitDriver) {
-            return; // not needed
-        }
-
-        // Ensure the URL is "stable", i.e. is not changing anymore; if it'd changing, some redirects are probably still in progress
-        for (int maxRedirects = 2; maxRedirects > 0; maxRedirects--) {
-            String currentUrl = webDriver.getCurrentUrl();
-            FluentWait<WebDriver> wait = new FluentWait<>(webDriver).withTimeout(Duration.of(250, ChronoUnit.MILLIS));
-            try {
-                wait.until(not(urlToBe(currentUrl)));
-            } catch (TimeoutException e) {
-                break; // URL has not changed recently - ok, the URL is stable and page is current
-            }
-            if (maxRedirects == 1) {
-                log.warn("URL seems unstable! (Some redirect are probably still in progress)");
-            }
-        }
-
-        WebDriverWait wait = new WebDriverWait(webDriver, PAGELOAD_TIMEOUT_MILLIS / 1000);
-
+    public boolean wasDenied() {
         try {
-            // Checks if the document is ready and asks AngularJS, if present, whether there are any REST API requests
-            // in progress
-            wait.until(javaScriptThrowsNoExceptions(
-                    "if (document.readyState !== 'complete' "
-                            + "|| (typeof angular !== 'undefined' && angular.element(document.body).injector().get('$http').pendingRequests.length !== 0)) {"
-                            + "throw \"Not ready\";"
-                            + "}"));
-        } catch (TimeoutException e) {
-            // Sometimes, for no obvious reason, the browser/JS doesn't set document.readyState to 'complete' correctly
-            // but that's no reason to let the test fail; after the timeout the page is surely fully loaded
-            log.warn("waitForPageToLoad time exceeded!");
+            waitGui().until().element(By.id("output")).text().matches("You can not access or perform the requested operation on this resource.");
         }
+        catch (TimeoutException e) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/app-authz-photoz/photoz-testsuite/src/test/resources/arquillian.xml
+++ b/app-authz-photoz/photoz-testsuite/src/test/resources/arquillian.xml
@@ -51,19 +51,11 @@
 
     <extension qualifier="webdriver">
         <property name="browser">${browser}</property>
-        <property name="downloadBinaries">${webdriverDownloadBinaries}</property>
-
-        <!-- firefox -->
-        <property name="firefox_binary">${firefox_binary}</property>
-        <property name="firefoxLogLevel">OFF</property>
-        <property name="firefoxLegacy">true</property>
-
-        <!-- chrome -->
-        <property name="chromeDriverBinary">${chromeDriverBinary}</property>
+        <property name="chromeArguments">--window-size=1920,1080</property>
     </extension>
 
     <extension qualifier="drone">
-        <property name="instantiationTimeoutInSeconds">${droneInstantiationTimeoutInSeconds}</property>
+        <property name="instantiationTimeoutInSeconds">60</property>
     </extension>
 
     <extension qualifier="graphene">

--- a/app-authz-uma-photoz/README.md
+++ b/app-authz-uma-photoz/README.md
@@ -18,7 +18,7 @@ Basically, it is a project containing three modules:
  
 * **photoz-restful-api**, a simple RESTFul API based on JAX-RS and acting as a resource server.
 * **photoz-html5-client**, a HTML5 + AngularJS client that will consume the RESTful API published by a resource server.
-* **photoz-authz-policy**, a simple project with some rule-based policies using JBoss Drools.
+* **photoz-js-policies**, a simple project with some rule-based policies using JavaScript.
 
 For this application, users can be regular users or administrators. Regular users can create/view/delete their albums 
 and administrators can do anything. Regular users are also allowed to share their albums with other users.
@@ -154,29 +154,26 @@ view the token contents, we will focus on the main functionality of the quicksta
 * Before creating any albums, click on the `My Profile` link. A page will display Alice's id and also the number of albums
 owned by Alice, which should be zero at this point.
 * The next step will be creating a couple of albums. Click on the `Create Album` link to add an album. For example purposes,
-let's crete two albums, named `Italy Vacations` and `Greece Vacations`.
+let's craete two albums, named `Italy Vacations` and `Greece Vacations`.
 * Clicking on the `My Profile` link now should show a total of two albums owned by Alice.
 * It is also possible to delete an album by clicking on the `[X]` link next to it but we won't do it for the moment.
 
 Alice can now manage her albums and share them with other users. Click on the `My Account` link at the top of the page. You
-will be directed to the Keycloak Account page. Next, click on `My Resources`. It will show the two albums created before in
+will be directed to the Keycloak Account page. Next, click on `Resources`. It will show the two albums created before in
 a table. Let's now share the albums with John Doe (jdoe):
 
-* Click on the `Italy Vacations` album. In the `Share with others` section fill the input field with the `jdoe` username
-and click on the `Share` button. By default both the `album:view` and `album:delete` scopes are set as permissions for
-John. 
-* The table at the top of the page now displays information about the shared album: the username with which the album was
-shared with, the permissions (scopes) this username has on the resource, the time and date of the permission grat and a
-`Revoke` buttom that Alice can use at any time to revoke access to her album.
-* Click again on the `My Resources` link in the left panel. Notice how the table of resources now has a shared symbol
-in the `Italy Vacations` album along with the number `1`, indicating the album has been shared with 1 other user.
-* Now click on the `Greece Vacations` album, enter `jdoe` in the input field but before clicking `Share` make sure to remove
-the `album:delete` scope.
-* The table at the top of the page again displays information about the shared resource. Notice how only the `album:view`
-scope has been set in the `Permission` column.
+* Click on the `Share` button for the `Italy Vacations` album. In the `Username or email` field enter the `jdoe` username
+  and click on the `Add` button. Click on the `Select the permissions` field and select both `album:view` and `album:delete`
+  permissions from the drop-down menu. Click `Done` to confirm the changes.
+* Alice can use the kebab menu for the `Italy Vacations` album at any time to view and change the permissions
+  or revoke the access completely.
+* Click the `ˬ` (arrow down) button next to `Italy Vacations` resource name to expand the box. Notice the information that
+  the resource is shared with `jdoe`.
+* Now, click on the `Share` button for the `Greece Vacations` album and enter `jdoe` username again. This time, select
+  only the `album:view` permission and confirm the dialog by clicking on the `Done` button.
 
-So, to summarize, Alice has shared both her albums with John, giving him full permissions on the `Italy Vacations` album
-and only the `album:view` permission on the `Greece Vacation` album.
+So, to summarize, Alice has shared both her albums with John, giving him full permissions (`album:view` and `album:delete`)
+on the `Italy Vacations` album and only the `album:view` permission on the `Greece Vacation` album.
 
 Now click on the `Back to photoz-html5-client` link at the top of the page to return to the application and then click on
 the `Sign Out` link to logout.
@@ -196,14 +193,13 @@ This tells John that he doesn't have the permissions to delete this album and if
 should still be able to see it when he logs (we will cover that part later on) because administrators should be able to
 see all the albums created by all users.
 * The next step is to request Alice the permissions to delete the `Greece Vacations` album. Click on the `Request Delete Access`
-link. The app display the following message:
+link. The app displays the following message:
    ````
    Sent authorization request to resource owner, please, wait for approval.
    ````
-* Next click on the `My Account` link at the top of the page and then click on `My Resources`. Notice how the page shows
-both John's own resources (the `Germany Vacations`) album and also the resources Alice shared with him. At any time John
-can remove the sharing by selecting the shared resource and clicking on the `Remove Sharing` button. This doesn't remove
-the resource, only the sharing.
+* Next click on the `My Account` link at the top of the page and then click on `Resources`. Notice how the page shows
+both John's own resources (the `Germany Vacations`) album and also the resources Alice shared with him (on `Shared with Me`
+tab).
 * We won't be doing anything for now on this page, so let's just logout. For that, simply click on the `Sign Out` link at
 the top of the page.
 
@@ -214,10 +210,10 @@ We know now that John has sent Alice a request to obtain `album:delete` for the 
 in as Alice (username: alice, password: alice). We should be take straight to the Keycloak Account page. If you land at the
 application main page click on the `My Account` link to go to the Keycloak Account page.
 
-Click on the `My Resources` link and now the page looks a little bit different. An extra table is displayed at the top of
-page with the approval requests. It shows that John has requested the `album:delete` permission for the `Greece Vacations`
-album and it also displays two buttons, `Approve` and `Deny`. At this moment we will approve John's request, so click on the
-`Approve` button.
+Click on the `Resources` link and now the page looks a little bit different. A button with `1` badge is displayed next to
+the `Greece Vacations` resource. After clicking that button a modal dialog appears. It shows that John has requested
+the `album:delete` permission for the album and it also displays two buttons, `Accept` and `Deny`. At this moment we will
+approve John's request, so click on the `Accept` button.
 
 Click on the `Back to photoz-html5-client` link at the top of the page and then logout by clicking on the `Sign out` link.
 
@@ -242,9 +238,11 @@ Revoking Permissions
 ---------
 
 As a final exercise let's say that Alice now doesn't trust John anymore so she wants to revoke the permissions she gave him.
-Log in as Alice (username: alice, password: alice) and go to `My Account` and then click on `My Resources`. She has now only
-one album (`Italy Vacations`) as we removed the other one as administrators. Click on the album and now the page shows the
-table of people with access to the resource. Click on the `Revoke` button to revoke the permissions granted to John.
+Log in as Alice (username: alice, password: alice) and go to `My Account` and then click on `Resources`. She has now only
+one album (`Italy Vacations`) as we removed the other one as administrators. Select `Edit` from the kebab menu for this
+resource, remove all permissions from the `Select the permissions` field and confirm the changes by clicking the "check"
+button next to that field. Finally, close the modal dialog by clicking `Done`. Alternatively, select `Unshare all` from
+the kebab menu which would revoke access from all users Alice shared the album with.
 
 Click on the `Back to photoz-html5-client` link and the logout. Log back in as John (username: jdoe, password: jdoe) and
 notice how John has not albums shared with him.
@@ -252,5 +250,11 @@ notice how John has not albums shared with him.
 Summary
 ----------
 
-This quickstart should provides a good overview of some of the core concepts of the Keycloak Authorization Services, such as
+This quickstart should provide a good overview of some of the core concepts of the Keycloak Authorization Services, such as
 user-managed access (privacy control), resource sharing, and asynchronous authorization.
+
+Integration test of the Quickstart
+----------------------------------
+
+1. Make sure you have an Keycloak server running with an admin user in the `master` realm or use the provided docker image.
+2. Run `mvn install -Pwildfly-managed`. Add `-Dbrowser=chrome` to run the tests without the headless browser mode.

--- a/app-authz-uma-photoz/photoz-html5-client/src/main/webapp/js/app.js
+++ b/app-authz-uma-photoz/photoz-html5-client/src/main/webapp/js/app.js
@@ -203,8 +203,10 @@ module.factory('authInterceptor', function ($q, $injector, $timeout, Identity) {
                         deferred.resolve(rejection);
                     }, function () {
                         document.getElementById("output").innerHTML = 'You can not access or perform the requested operation on this resource.';
+                        return deferred.reject(rejection);
                     }, function () {
                         document.getElementById("output").innerHTML = 'Unexpected error from server.';
+                        return deferred.reject(rejection);
                     });
 
                     var promise = deferred.promise;

--- a/app-authz-uma-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/pom.xml
@@ -30,11 +30,7 @@
     <description>Photoz UMA Testsuite</description>
 
     <properties>
-        <browser>firefox</browser>
-        <webdriverDownloadBinaries>true</webdriverDownloadBinaries>
-        <droneInstantiationTimeoutInSeconds>60</droneInstantiationTimeoutInSeconds>
-        <firefox_binary/>
-        <chromeDriverBinary/>
+        <browser>chromeheadless</browser>
     </properties>
 
     <dependencies>
@@ -52,10 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-phantom-driver</artifactId>
-            <version>${arquillian-phantom.version}</version>
-            <scope>test</scope>
+            <groupId>org.jboss.arquillian.graphene</groupId>
+            <artifactId>arquillian-browser-screenshooter</artifactId>
         </dependency>
     </dependencies>
 

--- a/app-authz-uma-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/ConsentPage.java
+++ b/app-authz-uma-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/ConsentPage.java
@@ -47,6 +47,6 @@ public class ConsentPage {
     }
 
     public boolean isCurrent() {
-        return driver.getTitle().equalsIgnoreCase("Log in to photoz");
+        return driver.getTitle().equalsIgnoreCase("Sign in to photoz");
     }
 }

--- a/app-authz-uma-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/PhotozPage.java
+++ b/app-authz-uma-photoz/photoz-testsuite/src/test/java/org/keycloak/quickstart/uma/page/PhotozPage.java
@@ -17,26 +17,16 @@
 
 package org.keycloak.quickstart.uma.page;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Assert;
 import org.keycloak.test.page.LoginPage;
 import org.openqa.selenium.By;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.jboss.arquillian.graphene.Graphene.waitGui;
-import static org.openqa.selenium.support.ui.ExpectedConditions.javaScriptThrowsNoExceptions;
-import static org.openqa.selenium.support.ui.ExpectedConditions.not;
-import static org.openqa.selenium.support.ui.ExpectedConditions.urlToBe;
 
 /**
  * A {@code {@link Page}} representing the Photoz application.
@@ -75,14 +65,9 @@ public class PhotozPage {
     @FindBy(id = "output")
     private WebElement output;
 
-    @FindBy(id = "referrer")
-    private WebElement backToAppLink;
-
 
     public void login(final String username, final String password, final String fullName) {
-        waitForPageToLoad();
         loginPage.login(username, password);
-        waitForPageToLoad();
         if (consentPage.isCurrent()) {
             consentPage.confirm();
         }
@@ -95,7 +80,6 @@ public class PhotozPage {
     public void logout() {
         waitGui().until().element(signOutLink).is().clickable();
         signOutLink.click();
-        waitForPageToLoad();
     }
 
     public void createAlbum(final String albumName) {
@@ -128,14 +112,12 @@ public class PhotozPage {
         waitGui().until().element(deleteLink).is().clickable();
         deleteLink.click();
         waitGui().until().element(deleteLink).is().not().present();
-        waitForPageToLoad();
     }
 
     private void viewAlbum(final WebElement viewLink) {
         waitGui().until().element(viewLink).is().clickable();
         viewLink.click();
         waitGui().until().element(viewLink).is().not().present();
-        waitForPageToLoad();
     }
 
     public void requestEntitlements() {
@@ -144,89 +126,10 @@ public class PhotozPage {
         waitGui().until().element(output).text().not().equalTo("");
     }
 
-    public void shareResource(String resource, String user) {
-        goToAccountMyResource(resource);
-        WebElement userIdInput = webDriver.findElement(By.id("user_id"));
-        waitGui().until().element(userIdInput).is().present();
-        userIdInput.sendKeys(user);
-        waitGui().until().element(userIdInput).attribute("value").contains(user);
-
-        WebElement shareButton = webDriver.findElement(By.id("share-button"));
-        waitGui().until().element(shareButton).is().clickable();
-        shareButton.click();
-        waitForPageToLoad();
-        waitGui().until().element(backToAppLink).is().clickable();
-        backToAppLink.click();
-        waitForPageToLoad();
-    }
-
-    public void shareResourceWithExcludedScope(String resource, String user, String scope) {
-        goToAccountMyResource(resource);
-        WebElement userIdInput = webDriver.findElement(By.id("user_id"));
-        waitGui().until().element(userIdInput).is().present();
-        userIdInput.sendKeys(user);
-        waitGui().until().element(userIdInput).attribute("value").contains(user);
-
-        WebElement shareRemoveScope = webDriver.findElement(By.id("share-remove-scope-" + resource + "-" + scope));
-        waitGui().until().element(shareRemoveScope).is().clickable();
-        shareRemoveScope.click();
-        waitForPageToLoad();
-
-        WebElement shareButton = webDriver.findElement(By.id("share-button"));
-        waitGui().until().element(shareButton).is().clickable();
-        shareButton.click();
-        waitForPageToLoad();
-        waitGui().until().element(backToAppLink).is().clickable();
-        backToAppLink.click();
-        waitForPageToLoad();
-    }
-
     public void requestDeleteScope(String albumName) {
         WebElement requestDeleteAccessLink = webDriver.findElement(By.id("request-delete-share-" + albumName));
         waitGui().until().element(requestDeleteAccessLink).is().clickable();
         requestDeleteAccessLink.click();
         waitGui().until().element(output).text().not().equalTo("");
     }
-
-    public void grantRequestedPermission(String resource, String requester) {
-        goToAccountMyResources();
-        WebElement grantRemoveScope = webDriver.findElement(By.id("grant-" + resource + "-" + requester));
-        waitGui().until().element(grantRemoveScope).is().clickable();
-        grantRemoveScope.click();
-        waitForPageToLoad();
-        waitGui().until().element(backToAppLink).is().clickable();
-        backToAppLink.click();
-        waitForPageToLoad();
-    }
-
-    public void goToAccountMyResource(String name) {
-        goToAccountMyResources();
-        WebElement myResource = webDriver.findElement(By.id("detail-" + name));
-        waitGui().until().element(myResource).is().clickable();
-        myResource.click();
-        waitForPageToLoad();
-    }
-
-    public void goToAccountMyResources() {
-        gotToAccountPage();
-        WebElement myResources = webDriver.findElement(By.xpath("//a[text() = 'My Resources']"));
-        waitGui().until().element(myResources).is().clickable();
-        myResources.click();
-        waitForPageToLoad();
-    }
-
-    public void gotToAccountPage() {
-        waitGui().until().element(myAccountLink).is().clickable();
-        myAccountLink.click();
-        waitForPageToLoad();
-    }
-
-    public void waitForPageToLoad() {
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-
 }

--- a/app-authz-uma-photoz/photoz-testsuite/src/test/resources/arquillian.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/src/test/resources/arquillian.xml
@@ -51,19 +51,11 @@
 
     <extension qualifier="webdriver">
         <property name="browser">${browser}</property>
-        <property name="downloadBinaries">${webdriverDownloadBinaries}</property>
-
-        <!-- firefox -->
-        <property name="firefox_binary">${firefox_binary}</property>
-        <property name="firefoxLogLevel">OFF</property>
-        <property name="firefoxLegacy">true</property>
-
-        <!-- chrome -->
-        <property name="chromeDriverBinary">${chromeDriverBinary}</property>
+        <property name="chromeArguments">--window-size=1920,1080</property>
     </extension>
 
     <extension qualifier="drone">
-        <property name="instantiationTimeoutInSeconds">${droneInstantiationTimeoutInSeconds}</property>
+        <property name="instantiationTimeoutInSeconds">60</property>
     </extension>
 
     <extension qualifier="graphene">


### PR DESCRIPTION
* Fixes both `app-authz-photoz` and `app-authz-uma-photoz` Quickstarts (both test and the QS were broken). Fixes are very similar for both QS, that's why I put them into a single PR.
* Switched to Chrome headless as it's more robust in tests than FF and also to align it with other QS.
* Updated the READMEs to reflect the new Account Console.
* Tests now uses Account REST API instead of UI not to rely on Account Console (which is out of scope of the tests here). This makes it more robust and stable.