### PR TITLE
Update keycloak-ingress.yaml

### DIFF
--- a/kubernetes-examples/keycloak-ingress.yaml
+++ b/kubernetes-examples/keycloak-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak


### PR DESCRIPTION
Hi all
This is a small fix in kube manifest file to remove warning found with recent minikube:
Warning: extensions/v1beta1 Ingress deprecation in v1.14+, unavailable in v1.22+

Thanks to have a look


