### PR TITLE
Adding default H2 db

### DIFF
--- a/kubernetes-examples/keycloak.yaml
+++ b/kubernetes-examples/keycloak.yaml
@@ -40,6 +40,8 @@ spec:
           value: "admin"
         - name: PROXY_ADDRESS_FORWARDING
           value: "true"
+        - name: DB_VENDOR
+          value: "H2"
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
I had to specify a DB as it failed to start keycloak without it (on microk8s 1.19)

No JIRA issue on this topic

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
