### PR TITLE
Update apiVersion to networking.k8s.io/v1 as extensions/v1beta1 has b…

### DIFF
--- a/kubernetes-examples/keycloak-ingress.yaml
+++ b/kubernetes-examples/keycloak-ingress.yaml
@@ -15,6 +15,6 @@ spec:
             name: keycloak
             port:
               number: 8080
-        path: /
+        path: /auth
         pathType: Exact
 

--- a/kubernetes-examples/keycloak-ingress.yaml
+++ b/kubernetes-examples/keycloak-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak
@@ -11,6 +11,10 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: keycloak
-          servicePort: 8080
+          service:
+            name: keycloak
+            port:
+              number: 8080
+        path: /
+        pathType: Exact
 


### PR DESCRIPTION
Updating apiVersion to networking.k8s.io/v1 in keycloak-ingress.yaml as extensions/v1beta1 has been deprecated in 1.20v

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
