### PR TITLE
KEYCLOAK-18003 Action token quickstarts can't be compiled

### DIFF
--- a/action-token-authenticator/src/main/java/org/keycloak/quickstart/actiontoken/token/ExternalApplicationNotificationActionTokenHandler.java
+++ b/action-token-authenticator/src/main/java/org/keycloak/quickstart/actiontoken/token/ExternalApplicationNotificationActionTokenHandler.java
@@ -20,7 +20,7 @@ import org.keycloak.Config.Scope;
 import org.keycloak.TokenVerifier;
 import org.keycloak.TokenVerifier.Predicate;
 import org.keycloak.authentication.AuthenticationProcessor;
-import org.keycloak.authentication.actiontoken.AbstractActionTokenHander;
+import org.keycloak.authentication.actiontoken.AbstractActionTokenHandler;
 import org.keycloak.authentication.actiontoken.*;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64;
@@ -40,7 +40,7 @@ import static org.keycloak.services.resources.LoginActionsService.AUTHENTICATE_P
  * Action token handler for verification of e-mail address.
  * @author hmlnarik
  */
-public class ExternalApplicationNotificationActionTokenHandler extends AbstractActionTokenHander<ExternalApplicationNotificationActionToken> {
+public class ExternalApplicationNotificationActionTokenHandler extends AbstractActionTokenHandler<ExternalApplicationNotificationActionToken> {
 
     public static final String QUERY_PARAM_APP_TOKEN = "app-token";
 

--- a/action-token-required-action/src/main/java/org/keycloak/quickstart/actiontoken/token/ExternalApplicationNotificationActionTokenHandler.java
+++ b/action-token-required-action/src/main/java/org/keycloak/quickstart/actiontoken/token/ExternalApplicationNotificationActionTokenHandler.java
@@ -20,7 +20,7 @@ import org.jboss.logging.Logger;
 import org.keycloak.Config.Scope;
 import org.keycloak.TokenVerifier;
 import org.keycloak.TokenVerifier.Predicate;
-import org.keycloak.authentication.actiontoken.AbstractActionTokenHander;
+import org.keycloak.authentication.actiontoken.AbstractActionTokenHandler;
 import org.keycloak.authentication.actiontoken.ActionTokenContext;
 import org.keycloak.authentication.actiontoken.TokenUtils;
 import org.keycloak.common.VerificationException;
@@ -47,7 +47,7 @@ import java.util.Collections;
  * Action token handler for verification of e-mail address.
  * @author hmlnarik
  */
-public class ExternalApplicationNotificationActionTokenHandler extends AbstractActionTokenHander<ExternalApplicationNotificationActionToken> {
+public class ExternalApplicationNotificationActionTokenHandler extends AbstractActionTokenHandler<ExternalApplicationNotificationActionToken> {
 
     public static final String QUERY_PARAM_APP_TOKEN = "app-token";
 


### PR DESCRIPTION
This fixes what was broken by https://github.com/keycloak/keycloak/pull/7985.

This may raise some concerns regarding backward compatibility (what if some other 3rd party provider relied on `AbstractActionTokenHander` as our QS). However, the breaking change was done in the `services` module which AFAIK is not considered as part of public SPI and breaking changes should be ok here.