### PR TITLE
doc(k8s): update ingress resource to new api version

### DIFF
--- a/kubernetes-examples/keycloak-ingress.yaml
+++ b/kubernetes-examples/keycloak-ingress.yaml
@@ -1,7 +1,8 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak
+  namespace: keycloak
 spec:
   tls:
     - hosts:
@@ -11,6 +12,7 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: keycloak
-          servicePort: 8080
-
+          service:
+            name: keycloak
+            port:
+              number: 8080

--- a/kubernetes-examples/keycloak-ingress.yaml
+++ b/kubernetes-examples/keycloak-ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak
-  namespace: keycloak
 spec:
   tls:
     - hosts:

--- a/kubernetes-examples/keycloak-ingress.yaml
+++ b/kubernetes-examples/keycloak-ingress.yaml
@@ -10,8 +10,11 @@ spec:
   - host: KEYCLOAK_HOST
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: Prefix
+        backend:
           service:
             name: keycloak
             port:
               number: 8080
+


### PR DESCRIPTION
Hello, I have created this MR to update the ingress resource since "extensions/v1beta1" for ingresses are deprecated, and new users from Kubernetes might have an up-to-date api-resource version

This MR is linked to this task on JIRA: https://issues.redhat.com/browse/KEYCLOAK-18329

I hope this might help :)