### PR TITLE
Node.js quickstart example - changing keyword declaration type

### DIFF
--- a/service-nodejs/app.js
+++ b/service-nodejs/app.js
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-var express = require('express');
-var session = require('express-session');
-var bodyParser = require('body-parser');
-var Keycloak = require('keycloak-connect');
-var cors = require('cors');
+const express = require('express');
+const session = require('express-session');
+const bodyParser = require('body-parser');
+const Keycloak = require('keycloak-connect');
+const cors = require('cors');
 
-var app = express();
+const app = express();
 app.use(bodyParser.json());
 
 // Enable CORS support
@@ -30,7 +30,7 @@ app.use(cors());
 // Create a session-store to be used by both the express-session
 // middleware and the keycloak middleware.
 
-var memoryStore = new session.MemoryStore();
+const memoryStore = new session.MemoryStore();
 
 app.use(session({
   secret: 'some secret',
@@ -45,7 +45,7 @@ app.use(session({
 // Additional configuration is read from keycloak.json file
 // installed from the Keycloak web console.
 
-var keycloak = new Keycloak({
+const keycloak = new Keycloak({
   store: memoryStore
 });
 

--- a/service-nodejs/test/app-test.js
+++ b/service-nodejs/test/app-test.js
@@ -57,7 +57,7 @@ registration.create(config.registration, config.testClient).then((v) => {
 
   test('Should test secured route with user credentials.', t => {
     tokenRequester(config.baseUrl, config.token).then((token) => {
-      var opt = {
+      const opt = {
         endpoint: 'http://localhost:3000/service/secured',
         headers: {
           Authorization: 'Bearer ' + token
@@ -78,7 +78,7 @@ registration.create(config.registration, config.testClient).then((v) => {
   test('Should test secured route with admin credentials.', t => {
     config.token.username = 'test-admin';
     tokenRequester(config.baseUrl, config.token).then((token) => {
-      var opt = {
+      const opt = {
         endpoint: 'http://localhost:3000/service/admin',
         headers: {
           Authorization: 'Bearer ' + token

--- a/service-nodejs/test/config.js
+++ b/service-nodejs/test/config.js
@@ -1,4 +1,4 @@
-var baseUrl = 'http://localhost:8180/auth';
+const baseUrl = 'http://localhost:8180/auth';
 
 module.exports = {
   registration: {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Changing Keyword type declaration type of all used variables of the Node.js quickstart example, from var to const.

Closes keycloak/keycloak-quickstarts#288

