### PR TITLE
Updating getting started guide for Dist.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ that can be used as a reference for your own project.
 ## Help and Documentation
 
 * [Documentation](https://www.keycloak.org/documentation.html)
+* [Server Guides](https://www.keycloak.org/guides#server)
 * [User Mailing List](https://lists.jboss.org/mailman/listinfo/keycloak-user) - Mailing list for help and general questions about Keycloak
 
 ## Reporting Security Vulnerabilities

--- a/app-angular2/README.md
+++ b/app-angular2/README.md
@@ -33,7 +33,8 @@ the the following command will install TypeScript:
 ````
 npm install -g typescript
 ````
-To build and run this project as a WAR you will need Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>

--- a/app-authz-jee-servlet/README.md
+++ b/app-authz-jee-servlet/README.md
@@ -31,9 +31,7 @@ You'll also learn how to use the `AuthorizationContext` object to obtain permiss
 System Requirements
 -------------------
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Configure the Client Adapter
 ----------------------------------

--- a/app-authz-jee-vanilla/README.md
+++ b/app-authz-jee-vanilla/README.md
@@ -21,9 +21,7 @@ You'll also learn how to use the `AuthorizationContext` object to obtain permiss
 System Requirements
 -------------------
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Configure the Client Adapter
 ----------------------------------

--- a/app-authz-photoz/README.md
+++ b/app-authz-photoz/README.md
@@ -69,6 +69,11 @@ regular access tokens instead of RPTs. The `photoz-html5-client` application doe
 obtain RPTs from the Keycloak server but just use the access token obtained during the authentication as a bearer token
 when accessing protected resources.
 
+System Requirements
+-------------------
+
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
+
 Create the Example Realm and a Resource Server
 -----------
 

--- a/app-authz-photoz/photoz-testsuite/src/test/resources/arquillian.xml
+++ b/app-authz-photoz/photoz-testsuite/src/test/resources/arquillian.xml
@@ -37,7 +37,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-${version.wildfly}</property>
             </configuration>
         </container>
-    
+
         <container qualifier="keycloak">
             <configuration>
                 <property name="managementAddress">127.0.0.1</property>

--- a/app-authz-springboot-multitenancy/README.md
+++ b/app-authz-springboot-multitenancy/README.md
@@ -48,7 +48,7 @@ Based on these initial settings, you should be able to not only support authenti
 System Requirements
 -------------------
 
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.1.1 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>

--- a/app-authz-springboot/README.md
+++ b/app-authz-springboot/README.md
@@ -41,7 +41,7 @@ You can use two distinct users to access this application:
 System Requirements
 -------------------
 
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>

--- a/app-authz-uma-photoz/photoz-testsuite/src/test/resources/arquillian.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/src/test/resources/arquillian.xml
@@ -37,7 +37,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-${version.wildfly}</property>
             </configuration>
         </container>
-    
+
         <container qualifier="keycloak">
             <configuration>
                 <property name="managementAddress">127.0.0.1</property>

--- a/app-jee-html5/README.md
+++ b/app-jee-html5/README.md
@@ -24,9 +24,7 @@ The quickstart requires that you have the [example services](../service-jee-jaxr
 services are located at `http://localhost:8080/service`. If the services are running elsewhere you need to edit
 `app.js` and replace the value of `serviceUrl`.
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>

--- a/app-jee-jsp/README.md
+++ b/app-jee-jsp/README.md
@@ -22,9 +22,7 @@ The quickstart requires that you have the [example services](../service-jee-jaxr
 services are located on the same host as the application. If the service is running elsewhere you need to set the URL
 of the service as an environment variable (SERVICE_URL) and restart <span>WildFly</span>.
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>

--- a/app-profile-jee-html5/README.md
+++ b/app-profile-jee-html5/README.md
@@ -22,10 +22,7 @@ As the example only contains static html pages the files in `src/main/webapp` ca
 System Requirements
 -------------------
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
-
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Configuration in <span>Keycloak</span>
 -----------------------

--- a/app-profile-jee-jsp/README.md
+++ b/app-profile-jee-jsp/README.md
@@ -19,10 +19,7 @@ display the token retrieved from <span>Keycloak</span>.
 System Requirements
 ------------
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
-
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Configuration in <span>Keycloak</span>
 -----------------------

--- a/app-profile-jee-vanilla/README.md
+++ b/app-profile-jee-vanilla/README.md
@@ -19,10 +19,7 @@ configuration is done automatically by the <span>Keycloak</span> client adapter 
 System Requirements
 -------------------
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
-
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Build and Deploy the Quickstart
 -------------------------------

--- a/app-profile-saml-jee-jsp/README.md
+++ b/app-profile-saml-jee-jsp/README.md
@@ -18,10 +18,7 @@ authenticates using <span>Keycloak</span> over the SAML protocol. Once authentic
 System Requirements
 -------------------
 
-If you are deploying the application as a WAR you need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
-
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Configuration in <span>Keycloak</span>
 -----------------------

--- a/app-springboot/README.md
+++ b/app-springboot/README.md
@@ -28,7 +28,7 @@ The quickstart requires that you have the [SpringBoot Service](../service-spring
 services are located at `http://localhost:8081/products`. If the services are running elsewhere you need to edit
 `resources/application.properties` and replace the value of `product.service.url`.
 
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>

--- a/docs/getting-started-legacy.md
+++ b/docs/getting-started-legacy.md
@@ -22,32 +22,53 @@ to replace it with the actual path to your installations.
 
 ## System Requirements
 
-The applications these projects produce are designed to be run on <span>WildFly</span> Application Server 10. 
-All you need to build these projects is Java 8 (Java SDK 1.8) and Maven 3.8.2 or later.
+The applications these projects produce are designed to be run on <span>WildFly</span> Application Server 10.
+
+All you need to build these projects is Java 8.0 (Java SDK 1.8) or later and Maven 3.1.1 or later.
+
 
 ## <a id="keycloak"></a>Start the <span>Keycloak</span> Server
 
-To start the <span>Keycloak</span> server as a container, run the following command:
+By default the <span>Keycloak</span> Server uses the same ports as the <span>WildFly</span> Server. To run the quickstarts you can either run the
+<span>Keycloak</span> Server on a separate host (machine, VM, Docker, etc..) or on different ports.
+
+To start the <span>Keycloak</span> server on a separate host:
+
+1. Open a terminal on the separate machine and navigate to the root of the <span>Keycloak</span> server directory.
+
+2. The following shows the command to start the <span>Keycloak</span> server:
 
    ````
-   podman|docker run --name keycloak -p 8180:8180 \
-        -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin \
-        quay.io/keycloak/keycloak:latest \
-        start-dev \
-        --http-port 8180 \
-        --http-relative-path /auth
+   For Linux:   KEYCLOAK_HOME/bin/standalone.sh -b 0.0.0.0
+   For Windows: KEYCLOAK_HOME\bin\standalone.bat -b 0.0.0.0
    ````
 
-The URL of the <span>Keycloak</span> server will be http://localhost:8180/auth.
+3. The URL of the <span>Keycloak</span> server will be http://&lt;HOSTNAME&gt;:8080 (replace &lt;HOSTNAME&gt; with the hostname of the separate host).
+
+To start the <span>Keycloak</span> server on different ports:
+
+1. Open a terminal and navigate to the root of the <span>Keycloak</span> server directory.
+
+2. The following shows the command to start the <span>Keycloak</span> server:
+
+   ````
+   For Linux:   KEYCLOAK_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=100
+   For Windows: KEYCLOAK_HOME\bin\standalone.bat -Djboss.socket.binding.port-offset=100
+   ````
+
+3. The URL of the <span>Keycloak</span> server will be http://localhost:8180
+
+## <a id="add-admin"></a>Add Admin User
+
+Open the main page for the <span>Keycloak</span> server ([localhost:8180](http://localhost:8180) or http://&lt;HOSTNAME&gt;:8080). If
+this is a new installation of <span>Keycloak</span> server you will be instructed to create an initial admin user. To continue with
+the quickstarts you need to do this prior to continuing.
 
 ## <a id="add-roles-user"></a>Create Roles and User
 
 To be able to use the examples you need to create some roles as well as at least one sample user. To do first this open
-the <span>Keycloak</span> admin console ([localhost:8180/admin](http://localhost:8180/admin) or http://&lt;HOSTNAME&gt;:8080/admin) and
-login with the admin credentials:
-
-* Username: admin
-* Password: admin
+the <span>Keycloak</span> admin console ([localhost:8180/auth/admin](http://localhost:8180/auth/admin) or http://&lt;HOSTNAME&gt;:8080/auth/admin) and
+login with the admin user you created in the [add admin user](#add-admin) section.
 
 Start by creating a user role:
 
@@ -84,9 +105,9 @@ One more step, if you want to access the examples with the admin user you need t
 
 Before starting the <span>WildFly</span> Server start by extracting the <span>Keycloak</span> client adapter into it.
 
-For <span>WildFly</span> extract `keycloak-wildfly-adapter-${project.version}.zip` into <span>WILDFLY_HOME</span>.
+For <span>WildFly 10</span> extract `keycloak-wildfly-adapter-${project.version}.zip` into <span>WILDFLY_HOME</span>.
 
-If you plan to try the SAML examples you also need the SAML <span>WildFly</span> adapter. To do this for <span>WildFly</span>
+If you plan to try the SAML examples you also need the SAML <span>WildFly</span> adapter. To do this for <span>WildFly 10</span>
 `keycloak-saml-wildfly-adapter-dist-${project.version}.zip` into <span>WILDFLY_HOME</span>.
 
 The next step is to start <span>WildFly</span> server:

--- a/productize.sh
+++ b/productize.sh
@@ -41,6 +41,9 @@ find . -type f \( -name "*README*" -o -name "*getting-started*" -o -name "*test-
 find . -type f \( -name "*README*" -o -name "*getting-started*" -o -name "*test-development*" \) -exec  sed -i 's@WILDFLY_HOME/bin@EAP_HOME/bin@g' {} +
 find . -type f \( -name "*README*" -o -name "*getting-started*" -o -name "*test-development*" \) -exec  sed -i 's@WILDFLY_HOME\\bin@EAP_HOME\\bin@g' {} +
 
+# Overrite files related to the legacy distribution
+cp docs/getting-started-legacy.md docs/getting-started.md
+
 # Remove JBoss Repo
 sed -i '/<repositories>/,/<\/repositories>/ d' pom.xml
 

--- a/service-jee-jaxrs/README.md
+++ b/service-jee-jaxrs/README.md
@@ -25,10 +25,7 @@ The endpoints are very simple and will only return a simple message stating what
 System Requirements
 -------------------
 
-You need to have <span>WildFly 10</span> running.
-
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
-
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 Configuration in <span>Keycloak</span>
 -----------------------

--- a/service-nodejs/README.md
+++ b/service-nodejs/README.md
@@ -27,6 +27,8 @@ System Requirements
 
 All you need to build this project is Node.js 4.0.0 or later.
 
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
+
 Configuration in <span>Keycloak</span>
 -----------------------
 

--- a/service-springboot-rest/README.md
+++ b/service-springboot-rest/README.md
@@ -25,7 +25,7 @@ There are 2 endpoints exposed by the service:
 System Requirements
 -------------------
 
-All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.3.3 or later.
+See the [Getting Started Guide](../docs/getting-started.md) for the minimum requirements and steps to build and run the quickstart.
 
 
 Configuration in <span>Keycloak</span>


### PR DESCRIPTION
Closes #286

* Changing guides for all quickstarts within the `Securing Apps` category. For these, tests should run fine.
* No changes to quickstarts within the `Extending the Server` category. For these, we are not able to do it properly without reviewing the test suite. Not sure if makes sense to add a note to each of them about this temporary situation and that they should use the Wildfly dist instead.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
