### PR TITLE
Update getting-started.md

### DIFF
--- a/action-token-authenticator/pom.xml
+++ b/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
     </parent>
 
     <name>Quickstart: Action Token With Authenticator</name>

--- a/action-token-authenticator/pom.xml
+++ b/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
     </parent>
 
     <name>Quickstart: Action Token With Authenticator</name>

--- a/action-token-required-action/pom.xml
+++ b/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
     </parent>
 
     <name>Quickstart: Action Token With Required Action</name>

--- a/action-token-required-action/pom.xml
+++ b/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
     </parent>
 
     <name>Quickstart: Action Token With Required Action</name>

--- a/app-authz-jee-servlet/pom.xml
+++ b/app-authz-jee-servlet/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-servlet/pom.xml
+++ b/app-authz-jee-servlet/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-vanilla/pom.xml
+++ b/app-authz-jee-vanilla/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-vanilla/pom.xml
+++ b/app-authz-jee-vanilla/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-js-policies/pom.xml
+++ b/app-authz-photoz/photoz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-photoz/photoz-js-policies/pom.xml
+++ b/app-authz-photoz/photoz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-restful-api</artifactId>

--- a/app-authz-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-restful-api</artifactId>

--- a/app-authz-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-testsuite</artifactId>

--- a/app-authz-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-testsuite</artifactId>

--- a/app-authz-photoz/pom.xml
+++ b/app-authz-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/pom.xml
+++ b/app-authz-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-rest-employee/pom.xml
+++ b/app-authz-rest-employee/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-rest-employee/pom.xml
+++ b/app-authz-rest-employee/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-spring-security/pom.xml
+++ b/app-authz-spring-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-spring-security/pom.xml
+++ b/app-authz-spring-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot-multitenancy/pom.xml
+++ b/app-authz-springboot-multitenancy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot-multitenancy/pom.xml
+++ b/app-authz-springboot-multitenancy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot/pom.xml
+++ b/app-authz-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot/pom.xml
+++ b/app-authz-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-uma-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-uma-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/photoz-js-policies/pom.xml
+++ b/app-authz-uma-photoz/photoz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-js-policies/pom.xml
+++ b/app-authz-uma-photoz/photoz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-uma-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-restful-api</artifactId>

--- a/app-authz-uma-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-uma-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-restful-api</artifactId>

--- a/app-authz-uma-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-testsuite</artifactId>

--- a/app-authz-uma-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-testsuite</artifactId>

--- a/app-authz-uma-photoz/pom.xml
+++ b/app-authz-uma-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/pom.xml
+++ b/app-authz-uma-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-html5/pom.xml
+++ b/app-jee-html5/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-html5/pom.xml
+++ b/app-jee-html5/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-html5/pom.xml
+++ b/app-profile-jee-html5/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-html5/pom.xml
+++ b/app-profile-jee-html5/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-vanilla/pom.xml
+++ b/app-profile-jee-vanilla/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-vanilla/pom.xml
+++ b/app-profile-jee-vanilla/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-saml-jee-jsp/pom.xml
+++ b/app-profile-saml-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-saml-jee-jsp/pom.xml
+++ b/app-profile-saml-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-springboot/pom.xml
+++ b/app-springboot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-springboot/pom.xml
+++ b/app-springboot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authz-js-policies/pom.xml
+++ b/authz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz-js-policies/pom.xml
+++ b/authz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-These quickstarts run on <span>WildFly 10</span>.
+These quickstarts run on <span>WildFly 23</span> onwards.
 
 Prior to running the quickstarts you should read this entire document and have completed the following steps:
 
@@ -97,7 +97,11 @@ The next step is to start <span>WildFly</span> server:
    For Linux:   WILDFLY_HOME/bin/standalone.sh
    For Windows: WILDFLY_HOME\bin\standalone.bat
    ````
-3. To install the <span>Keycloak</span> adapter run the following commands:
+3. Use of an adapter is required to run Keycloak with Wildlfy. Depending on the version of Wildlfy used the adapters required will change.
+<br>To install the <span>Keycloak</span> adapter run the following commands:
+
+<h4>Legacy Adapter</h4>
+
    ````
    For Linux:
 
@@ -109,6 +113,21 @@ The next step is to start <span>WildFly</span> server:
     WILDFLY_HOME\bin\jboss-cli.bat -c --file=WILDFLY_HOME\bin\adapter-install.cli
     WILDFLY_HOME\bin\jboss-cli.bat -c --command=:reload
    ````
+ <h4>Elytron Adapter</h4>
+ 
+   ````
+   For Linux:
+   
+    WILDFLY_HOME/bin/jboss-cli.sh -c --file=WILDFLY_HOME/bin/adapter-elytron-install.cli
+    WILDFLY_HOME/bin/jboss-cli.sh -c --command=:reload
+    
+   For Windows:
+   
+    WILDFLY_HOME\bin\jboss-cli.bat -c --file=WILDFLY_HOME\bin\adapter-elytron-install.cli
+    WILDFLY_HOME\bin\jboss-cli.bat -c --command=:reload
+   ````   
+   
+   
 4. If you plan to try the SAML examples you also need to install <span>Keycloak</span> SAML adapter:
 
    ````

--- a/event-listener-sysout/pom.xml
+++ b/event-listener-sysout/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Listener System.out</name>

--- a/event-listener-sysout/pom.xml
+++ b/event-listener-sysout/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Listener System.out</name>

--- a/event-store-mem/pom.xml
+++ b/event-store-mem/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Store In-Mem</name>

--- a/event-store-mem/pom.xml
+++ b/event-store-mem/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Store In-Mem</name>

--- a/extend-account-console/pom.xml
+++ b/extend-account-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extend-account-console/pom.xml
+++ b/extend-account-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kubernetes-examples/keycloak.yaml
+++ b/kubernetes-examples/keycloak.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: keycloak
-        image: quay.io/keycloak/keycloak:19.0.2
+        image: quay.io/keycloak/keycloak:19.0.3
         args: ["start-dev"]
         env:
         - name: KEYCLOAK_ADMIN

--- a/kubernetes-examples/keycloak.yaml
+++ b/kubernetes-examples/keycloak.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: keycloak
-        image: quay.io/keycloak/keycloak:nightly
+        image: quay.io/keycloak/keycloak:19.0.2
         args: ["start-dev"]
         env:
         - name: KEYCLOAK_ADMIN

--- a/openshift-examples/keycloak.yaml
+++ b/openshift-examples/keycloak.yaml
@@ -65,7 +65,7 @@ objects:
                   value: '${KEYCLOAK_ADMIN_PASSWORD}'
                 - name: KC_PROXY
                   value: 'edge'
-              image: quay.io/keycloak/keycloak:19.0.2
+              image: quay.io/keycloak/keycloak:19.0.3
               livenessProbe:
                 failureThreshold: 100
                 httpGet:

--- a/openshift-examples/keycloak.yaml
+++ b/openshift-examples/keycloak.yaml
@@ -65,7 +65,7 @@ objects:
                   value: '${KEYCLOAK_ADMIN_PASSWORD}'
                 - name: KC_PROXY
                   value: 'edge'
-              image: quay.io/keycloak/keycloak:nightly
+              image: quay.io/keycloak/keycloak:19.0.2
               livenessProbe:
                 failureThreshold: 100
                 httpGet:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>19.0.2</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>19.0.2</version>
+    <version>19.0.3</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-springboot-rest/pom.xml
+++ b/service-springboot-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-springboot-rest/pom.xml
+++ b/service-springboot-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa-legacy/pom.xml
+++ b/user-storage-jpa-legacy/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa-legacy/pom.xml
+++ b/user-storage-jpa-legacy/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-simple/pom.xml
+++ b/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>19.0.2</version>
+        <version>19.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-simple/pom.xml
+++ b/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>19.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Changes recommended to Wildfly recommendation from outdated Wildfly 10 to Wildfly 23 onwards.

Adapter changes recommended.

Unsure about what version exactly that Wildfly Elyton is required for.  It is needed with version 23.0.2

Closes Issue: #359

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
