### PR TITLE
 app-profile-saml-jee-jsp remove "/auth"

### DIFF
--- a/app-profile-saml-jee-jsp/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
+++ b/app-profile-saml-jee-jsp/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
@@ -80,7 +80,7 @@ public class Controller {
     private String findKeycloakServerPath(HttpServletRequest req) {
         String bindingUrl = getBindingUrl(req);
         // bindingUrl looks like http://localhost:8080/auth/realms/master/protocol/saml
-        return bindingUrl.substring(0, bindingUrl.indexOf("/auth")) + "/auth";
+        return bindingUrl.substring(0, bindingUrl.indexOf("/realms"));
     }
 
     private String getBindingUrl(HttpServletRequest req) {


### PR DESCRIPTION
/auth does no longer exist in newer keycloak versions.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
