### PR TITLE
Use a valid SemVer format for the SNAPSHOT version

### DIFF
--- a/action-token-authenticator/pom.xml
+++ b/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Quickstart: Action Token With Authenticator</name>

--- a/action-token-required-action/pom.xml
+++ b/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Quickstart: Action Token With Required Action</name>

--- a/app-authz-jee-servlet/pom.xml
+++ b/app-authz-jee-servlet/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-jee-vanilla/pom.xml
+++ b/app-authz-jee-vanilla/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-photoz/photoz-js-policies/pom.xml
+++ b/app-authz-photoz/photoz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-restful-api</artifactId>

--- a/app-authz-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-testsuite</artifactId>

--- a/app-authz-photoz/pom.xml
+++ b/app-authz-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-rest-employee/pom.xml
+++ b/app-authz-rest-employee/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-spring-security/pom.xml
+++ b/app-authz-spring-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot-multitenancy/pom.xml
+++ b/app-authz-springboot-multitenancy/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-springboot/pom.xml
+++ b/app-authz-springboot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-html5-client/pom.xml
+++ b/app-authz-uma-photoz/photoz-html5-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-authz-uma-photoz/photoz-js-policies/pom.xml
+++ b/app-authz-uma-photoz/photoz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/app-authz-uma-photoz/photoz-restful-api/pom.xml
+++ b/app-authz-uma-photoz/photoz-restful-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-restful-api</artifactId>

--- a/app-authz-uma-photoz/photoz-testsuite/pom.xml
+++ b/app-authz-uma-photoz/photoz-testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>app-authz-uma-photoz-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>photoz-uma-testsuite</artifactId>

--- a/app-authz-uma-photoz/pom.xml
+++ b/app-authz-uma-photoz/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-html5/pom.xml
+++ b/app-jee-html5/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-jee-jsp/pom.xml
+++ b/app-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-html5/pom.xml
+++ b/app-profile-jee-html5/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-jsp/pom.xml
+++ b/app-profile-jee-jsp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-jee-vanilla/pom.xml
+++ b/app-profile-jee-vanilla/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-profile-saml-jee-jsp/pom.xml
+++ b/app-profile-saml-jee-jsp/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/app-springboot/pom.xml
+++ b/app-springboot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authz-js-policies/pom.xml
+++ b/authz-js-policies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/event-listener-sysout/pom.xml
+++ b/event-listener-sysout/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Listener System.out</name>

--- a/event-store-mem/pom.xml
+++ b/event-store-mem/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Keycloak Quickstart: Event Store In-Mem</name>

--- a/extend-account-console/pom.xml
+++ b/extend-account-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>999.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/scripts/export-keycloak-version.sh
+++ b/scripts/export-keycloak-version.sh
@@ -3,5 +3,5 @@
 if [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n "$QUICKSTART_BRANCH" && "$QUICKSTART_BRANCH" != "main" ) ]]; then
   export KEYCLOAK_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
 else
-  export KEYCLOAK_VERSION="999-SNAPSHOT"
+  export KEYCLOAK_VERSION="999.0.0-SNAPSHOT"
 fi

--- a/scripts/prepare-local-server.sh
+++ b/scripts/prepare-local-server.sh
@@ -8,7 +8,7 @@ if [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n
   URL="https://github.com/keycloak/keycloak/releases/download/${VERSION}/keycloak-${VERSION}.tar.gz"
 else
   echo "Downloading nightly Keycloak release"
-  URL="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999-SNAPSHOT.tar.gz"
+  URL="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.tar.gz"
 fi
 
 wget -q -O keycloak-dist.tar.gz "$URL"

--- a/service-jee-jaxrs/pom.xml
+++ b/service-jee-jaxrs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/service-springboot-rest/pom.xml
+++ b/service-springboot-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa-legacy/pom.xml
+++ b/user-storage-jpa-legacy/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-storage-simple/pom.xml
+++ b/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Changes the default version string from `999-SNAPSHOT` to `999.0.0-SNAPSHOT`. This makes it a valid version under the [Semantic Versioning](https://semver.org/) standard.

The motivation for this change is to make versioning interoperable between Maven and NPM, as the latter only allows for Semantic Versioning. This allows for simplification in the release process, as we no longer need to convert version numbers from one to the other.

For more information see https://github.com/keycloak/keycloak/issues/17335.