### PR TITLE
Set springboot pom version

### DIFF
--- a/app-authz-rest-employee/pom.xml
+++ b/app-authz-rest-employee/pom.xml
@@ -110,6 +110,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
         </plugins>
     </build>

--- a/app-authz-rest-springboot/pom.xml
+++ b/app-authz-rest-springboot/pom.xml
@@ -110,6 +110,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/app-authz-spring-security/pom.xml
+++ b/app-authz-spring-security/pom.xml
@@ -108,6 +108,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/app-authz-springboot-multitenancy/pom.xml
+++ b/app-authz-springboot-multitenancy/pom.xml
@@ -116,6 +116,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
         </plugins>
     </build>

--- a/app-authz-springboot/pom.xml
+++ b/app-authz-springboot/pom.xml
@@ -105,6 +105,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/app-springboot/pom.xml
+++ b/app-springboot/pom.xml
@@ -110,6 +110,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/service-springboot-rest/pom.xml
+++ b/service-springboot-rest/pom.xml
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${springboot-version}</version>
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
The issue was that in the pom wasn't indicated the springboot plugin version. 
As results the most recent version was taken from https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-maven-plugin. Recent update was 23 of February.

Using latest version was causing this error:
`[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:3.0.3:run (default-cli) on project service-springboot: Execution default-cli of goal org.springframework.boot:spring-boot-maven-plugin:3.0.3:run failed: Unable to load the mojo 'run' in the plugin 'org.springframework.boot:spring-boot-maven-plugin:3.0.3' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/springframework/boot/maven/RunMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
`



Closes: https://github.com/keycloak/keycloak-quickstarts/issues/378