### PR TITLE
Remove nashorn dependency, which is no longer needed in quickstarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,14 @@ jobs:
       - name: Get Keycloak
         run: scripts/prepare-local-server.sh
 
+      - name: Build Quickstarts
+        run: scripts/build-quickstarts.sh jakarta
+
       - name: Start Keycloak
         run: scripts/start-local-server.sh
 
       - name: Run unit tests
-        run: |
-          mvn -Djakarta -Pwildfly-managed clean package verify
+        run: scripts/run-tests.sh jakarta
 
   tests-spring:
     name: Spring Quickstarts Tests
@@ -117,6 +119,9 @@ jobs:
 
       - name: Get Keycloak
         run: scripts/prepare-local-server.sh
+
+      - name: Build Quickstarts
+        run: scripts/build-quickstarts.sh jakarta
 
       - name: Start Keycloak
         run: scripts/start-local-server.sh

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <version.hamcrest>1.3</version.hamcrest>
         <version.creaper>1.6.1</version.creaper>
         <version.shrinkwrap.resolvers>3.1.4</version.shrinkwrap.resolvers>
+        <version.jee.jaxb.api>2.3.1</version.jee.jaxb.api>
 
         <arquillian-managed>true</arquillian-managed>
         <jboss-cli.executable>./jboss-cli.sh</jboss-cli.executable>
@@ -486,6 +487,8 @@
             <modules>
                 <module>app-authz-jakarta-servlet</module>
                 <module>app-jakarta-rs</module>
+                <module>user-storage-simple</module>
+                <module>user-storage-jpa</module>
                 <!--
                 WIP
                 Spring requires JDK 17 and we are not yet ready to build on top of this version
@@ -498,7 +501,7 @@
                     <dependency>
                         <groupId>org.wildfly.bom</groupId>
                         <artifactId>wildfly-ee-with-tools</artifactId>
-                        <version>28.0.0.Beta1</version>
+                        <version>${version.wildfly}</version>
                         <type>pom</type>
                         <scope>import</scope>
                     </dependency>
@@ -580,8 +583,6 @@
                 <module>app-profile-saml-jee-jsp</module>
                 <module>authz-js-policies</module>
                 <module>extend-account-console</module>
-                <module>user-storage-simple</module>
-                <module>user-storage-jpa</module>
             </modules>
             <dependencyManagement>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <arquillian-drone-bom.version>2.5.1</arquillian-drone-bom.version>
         <version.json.javax>1.1.2</version.json.javax>
         <version.yasson>1.0.8</version.yasson>
-        <version.nashorn>15.3</version.nashorn>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -151,11 +150,6 @@
                 <groupId>org.eclipse</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${version.yasson}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openjdk.nashorn</groupId>
-                <artifactId>nashorn-core</artifactId>
-                <version>${version.nashorn}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>

--- a/scripts/build-quickstarts.sh
+++ b/scripts/build-quickstarts.sh
@@ -15,6 +15,11 @@ for f in $(find . -type f -name 'keycloak-saml-example.xml'); do
    cp "$f" "${f%-example.xml}.xml"
 done
 
+if [ "$1" = "jakarta" ]; then
+  echo "Using jakarta profile when building maven artifacts"
+  args="$args -Djakarta"
+fi
+
 mvn clean install $args -DskipTests -B -Dnightly
 if [ -n "$PRODUCT" ] && [ "$PRODUCT" == "true" ]; then
   dist=$PRODUCT_DIST
@@ -22,7 +27,11 @@ else
   dist="keycloak-dist"
 fi
 
-cp authz-js-policies/target/authz-js-policies.jar $dist/providers
-cp user-storage-simple/target/user-storage-properties-example.jar $dist/providers
-cp user-storage-jpa/conf/quarkus.properties $dist/conf
-cp user-storage-jpa/target/user-storage-jpa-example.jar $dist/providers
+if [ "$1" != "jakarta" ]; then
+  cp authz-js-policies/target/authz-js-policies.jar $dist/providers
+else
+  cp user-storage-simple/target/user-storage-properties-example.jar $dist/providers
+  cp user-storage-jpa/conf/quarkus.properties $dist/conf
+  cp user-storage-jpa/target/user-storage-jpa-example.jar $dist/providers
+fi
+

--- a/user-storage-jpa/pom.xml
+++ b/user-storage-jpa/pom.xml
@@ -65,16 +65,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
-            <version>${version.hibernate.javax.persistence}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>
             <artifactId>graphene-webdriver</artifactId>
             <version>${arquillian-graphene.version}</version>
             <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- Only needed for testing by arquillian (ExporterRegistrationHandler requires JEE JAXB) -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${version.jee.jaxb.api}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/user-storage-jpa/src/main/java/org/keycloak/quickstart/storage/user/MyUserStorageProvider.java
+++ b/user-storage-jpa/src/main/java/org/keycloak/quickstart/storage/user/MyUserStorageProvider.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.quickstart.storage.user;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import org.jboss.logging.Logger;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
@@ -37,8 +39,6 @@ import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;

--- a/user-storage-jpa/src/main/java/org/keycloak/quickstart/storage/user/UserEntity.java
+++ b/user-storage-jpa/src/main/java/org/keycloak/quickstart/storage/user/UserEntity.java
@@ -16,10 +16,11 @@
  */
 package org.keycloak.quickstart.storage.user;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>

--- a/user-storage-jpa/src/main/resources/META-INF/persistence.xml
+++ b/user-storage-jpa/src/main/resources/META-INF/persistence.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.0"
-             xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="
-        http://java.sun.com/xml/ns/persistence
-        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
     <persistence-unit name="user-store" transaction-type="JTA">
         <class>org.keycloak.quickstart.storage.user.UserEntity</class>
         <properties>
-            <property name="hibernate.dialect" value="io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect" />
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
             <!-- Sets the name of the datasource to be the same as the datasource name in quarkus.properties-->
             <property name="hibernate.connection.datasource" value="user-store" />
-            <property name="javax.persistence.transactionType" value="JTA" />
+            <property name="jakarta.persistence.transactionType" value="JTA" />
             <property name="hibernate.hbm2ddl.auto" value="update" />
             <property name="hibernate.show_sql" value="false" />
         </properties>

--- a/user-storage-jpa/src/test/java/org/keycloak/quickstart/ArquillianJpaStorageTest.java
+++ b/user-storage-jpa/src/test/java/org/keycloak/quickstart/ArquillianJpaStorageTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.quickstart;
 
+import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
@@ -33,7 +34,6 @@ import org.keycloak.test.page.LoginPage;
 import org.keycloak.quickstart.storage.user.MyExampleUserStorageProviderFactory;
 import org.openqa.selenium.WebDriver;
 
-import javax.ws.rs.core.Response;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;

--- a/user-storage-simple/pom.xml
+++ b/user-storage-simple/pom.xml
@@ -78,6 +78,13 @@
             <groupId>org.jboss.arquillian.graphene</groupId>
             <artifactId>arquillian-browser-screenshooter</artifactId>
         </dependency>
+        <!-- Only needed for testing by arquillian (ExporterRegistrationHandler requires JEE JAXB) -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${version.jee.jaxb.api}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/user-storage-simple/src/test/java/org/keycloak/quickstart/ArquillianSimpleStorageTest.java
+++ b/user-storage-simple/src/test/java/org/keycloak/quickstart/ArquillianSimpleStorageTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.quickstart;
 
+import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
@@ -34,7 +35,6 @@ import org.keycloak.test.FluentTestsHelper;
 import org.keycloak.test.page.LoginPage;
 import org.openqa.selenium.WebDriver;
 
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
closes #407

- Fixes `user-storage-simple` and `user-storage-jpa` quickstarts to work with latest Keycloak on quarkus3
- Fixes compilation failures in quickstarts

TBD: Tests are still failing (due the tests in user-storage-* are still trying to use resteasy 3 instead of resteasy6 - not yet exactly sure why...
