### PR TITLE
Deployment fix for Jakarta Quickstarts

### DIFF
--- a/extension/action-token-authenticator/pom.xml
+++ b/extension/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/action-token-required-action/pom.xml
+++ b/extension/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/event-listener-sysout/pom.xml
+++ b/extension/event-listener-sysout/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/event-store-mem/pom.xml
+++ b/extension/event-store-mem/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/extend-account-console/pom.xml
+++ b/extension/extend-account-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/user-storage-jpa/pom.xml
+++ b/extension/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extension/user-storage-simple/pom.xml
+++ b/extension/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/jaxrs-resource-server/README.md
+++ b/jakarta/jaxrs-resource-server/README.md
@@ -1,9 +1,9 @@
 jakarta-jaxrs-resource-server: JAX-RS Resource Server
 ===================================================
 
-Level: Beginner
-Technologies: Jakarta EE
-Summary: A JAX-RS resource server protected with Wildfly Elytron OIDC
+Level: Beginner \
+Technologies: Jakarta EE \
+Summary: A JAX-RS resource server protected with Wildfly Elytron OIDC\
 Target Product: <span>Keycloak</span>, <span>WildFly</span>
 
 What is it?
@@ -30,7 +30,7 @@ Starting and Configuring the Keycloak Server
 To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
-docker run --name keycloak \
+docker run --name keycloak \  
   -e KEYCLOAK_ADMIN=admin \
   -e KEYCLOAK_ADMIN_PASSWORD=admin \
   --network=host \
@@ -45,8 +45,10 @@ You should be able to access your Keycloak Server at http://localhost:8180.
 
 Log in as the admin user to access the Keycloak Administration Console. Username should be `admin` and password `admin`.
 
-Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the Keycloak documentation about how to [create a new realm](https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm).
+Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`. The easiest way to do this is using the gui. After you click on `Create Realm`, you have the option to choose a Resource JSON file.
+
+You can also import the realm with cli.
+For more details, see the Keycloak documentation about how to [import a realm using cli](https://www.keycloak.org/docs/latest/server_admin/index.html#importing-a-realm-from-exported-json-file) and [create a new realm](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-a-realm_server_administration_guide).
 
 Starting the Wildfly Server
 -------------------
@@ -54,6 +56,8 @@ Starting the Wildfly Server
 In order to deploy the example application, you need a Wildfly Server up and running. For more details, see the Wildfly documentation about how to [install the server](https://docs.wildfly.org/).
 
 Make sure the server is accessible from `localhost` and listening on port `8080`.
+
+> You no longer need the Keycloak OIDC Client Adapter anymore as `elytron-oidc-client` subsystem  has been added to Wildfly 25
 
 Build and Deploy the Quickstart
 -------------------------------
@@ -71,9 +75,9 @@ Access the Quickstart
 
 There are 3 endpoints exposed by the service:
 
-* http://localhost:8080/service/public - requires no authentication
-* http://localhost:8080/service/secured - can be invoked by users with the `user` role
-* http://localhost:8080/service/admin - can be invoked by users with the `admin` role
+* http://localhost:8080/jakarta-jaxrs-resource-server/public - requires no authentication
+* http://localhost:8080/jakarta-jaxrs-resource-server/secured - can be invoked by users with the `user` role
+* http://localhost:8080/jakarta-jaxrs-resource-server/admin - can be invoked by users with the `admin` role
 
 You can open the public endpoint directly in the browser to test the service. The two other endpoints are protected and require
 invoking them with a bearer token.

--- a/jakarta/jaxrs-resource-server/pom.xml
+++ b/jakarta/jaxrs-resource-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/servlet-authz-client/README.md
+++ b/jakarta/servlet-authz-client/README.md
@@ -1,9 +1,9 @@
 jakarta-servlet-authz-client: Servlet Application Using Fine-grained Authorization
 ================================================
 
-Level: Beginner  
-Technologies: Jakarta EE
-Summary: Servlet application protected with Elytron OIDC and Keycloak Authorization Services  
+Level: Beginner \
+Technologies: Jakarta EE \
+Summary: Servlet application protected with Elytron OIDC and Keycloak Authorization Services \
 Target Product: <span>Keycloak</span>, <span>WildFly</span>
 
 What is it?
@@ -58,8 +58,10 @@ You should be able to access your Keycloak Server at http://localhost:8180.
 
 Log in as the admin user to access the Keycloak Administration Console. Username should be `admin` and password `admin`.
 
-Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the Keycloak documentation about how to [create a new realm](https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm).
+Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`. The easiest way to do this is using the gui.  After you click on `Create Realm`, you have the option to choose a Resource JSON file.
+
+You can also import the realm with cli.
+For more details, see the Keycloak documentation about how to [import a realm using cli](https://www.keycloak.org/docs/latest/server_admin/index.html#importing-a-realm-from-exported-json-file) and [create a new realm](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-a-realm_server_administration_guide).
 
 Starting the Wildfly Server
 -------------------
@@ -67,6 +69,8 @@ Starting the Wildfly Server
 In order to deploy the example application, you need a Wildfly Server up and running. For more details, see the Wildfly documentation about how to [install the server](https://docs.wildfly.org/).
 
 Make sure the server is accessible from `localhost` and listening on port `8080`. 
+
+> You no longer need the Keycloak OIDC Client Adapter anymore as `elytron-oidc-client` subsystem  has been added to Wildfly 25
 
 Build and Deploy the Quickstart
 -------------------------------

--- a/jakarta/servlet-authz-client/pom.xml
+++ b/jakarta/servlet-authz-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>jakarta-servlet-authz-client</artifactId>

--- a/jakarta/servlet-saml-service-provider/README.md
+++ b/jakarta/servlet-saml-service-provider/README.md
@@ -1,9 +1,9 @@
 servlet-saml-service-provider: Servlet SAML Service Provider
 =============================================================
 
-Level: Beginner
-Technologies: JavaEE
-Summary: JSP Profile Application
+Level: Beginner \
+Technologies: JavaEE \
+Summary: JSP Profile Application \
 Target Product: <span>Keycloak</span>, <span>WildFly</span>
 
 What is it?
@@ -17,9 +17,9 @@ System Requirements
 
 To compile and run this quickstart you will need:
 
-* JDK 11
+* JDK 17
 * Apache Maven 3.8.6
-* Wildfly 28+
+* Wildfly <= 23
 * Keycloak 21+
 * Docker 20+
 
@@ -44,8 +44,10 @@ You should be able to access your Keycloak Server at http://localhost:8180.
 
 Log in as the admin user to access the Keycloak Administration Console. Username should be `admin` and password `admin`.
 
-Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the Keycloak documentation about how to [create a new realm](https://www.keycloak.org/docs/latest/server_admin/index.html#_create-realm).
+Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`. The easiest way to do this is using the gui. After you click on `Create Realm`, you have the option to choose a Resource JSON file.
+
+You can also import the realm with cli.
+For more details, see the Keycloak documentation about how to [import a realm using cli](https://www.keycloak.org/docs/latest/server_admin/index.html#importing-a-realm-from-exported-json-file) and [create a new realm](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-a-realm_server_administration_guide).
 
 Starting the Wildfly Server
 -------------------
@@ -53,6 +55,15 @@ Starting the Wildfly Server
 In order to deploy the example application, you need a Wildfly Server up and running. For more details, see the Wildfly documentation about how to [install the server](https://docs.wildfly.org/).
 
 Make sure the server is accessible from `localhost` and listening on port `8080`.
+
+Installing the SAML 2.0 Wildfly Adapter
+-----------------------------------
+
+Install the WildFly SAML 2.0 Client Adapter following [this guide](https://www.keycloak.org/docs/latest/securing_apps/index.html#_saml-jboss-adapter-installation).
+
+> Please consider the supported WildFly version for this adapter
+
+
 
 Build and Deploy the Quickstart
 -------------------------------

--- a/jakarta/servlet-saml-service-provider/pom.xml
+++ b/jakarta/servlet-saml-service-provider/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>22.0.1</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <version.jee.jaxb.api>2.3.1</version.jee.jaxb.api>
 
         <arquillian-managed>true</arquillian-managed>
-        <version.wildfly.maven.plugin>1.2.2.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>4.1.1.Final</version.wildfly.maven.plugin>
         <jboss-cli.executable>./jboss-cli.sh</jboss-cli.executable>
         <keycloak.management.port>10090</keycloak.management.port>
         <selenium-bom.version>3.11.0</selenium-bom.version>

--- a/spring/rest-authz-resource-server/pom.xml
+++ b/spring/rest-authz-resource-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Closes #469 

Fixes the QS deployment exactly as suggested.

Fixed documentation for Jakarta Quickstarts: realm import, OIDC integration in Wildfly, project requirements, URLs.

Updated outdated dependency for wildfly maven plugin.