### PR TITLE
set version fix

### DIFF
--- a/.github/scripts/start-local-server.sh
+++ b/.github/scripts/start-local-server.sh
@@ -33,6 +33,6 @@ if [ "$1" = "extension" ]; then
   fi
 fi
 
-eval exec "$dist/bin/kc.sh start-dev --http-port=8180 $SERVER_ARGS > keycloak.log 2>&1 &"
+eval exec "$dist/bin/kc.sh start-dev --http-port=8180 $SERVER_ARGS" | tee keycloak.log &
 
-wget --retry-connrefused --waitretry=3 --read-timeout=20 --timeout=15 -t 30 http://localhost:8180
+wget --retry-connrefused --waitretry=3 --read-timeout=20 --timeout=15 -t 30 http://localhost:8180 --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  DEFAULT_JDK_VERSION: 17
+  DEFAULT_JDK_DIST: temurin
+
 jobs:
 
   tests:
@@ -12,9 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
       - name: Update maven settings
         run: mkdir -p ~/.m2 ; cp .github/maven-settings.xml ~/.m2/
 
@@ -41,9 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
       - name: Update maven settings
         run: mkdir -p ~/.m2 ; cp .github/maven-settings.xml ~/.m2/
 
@@ -73,6 +79,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
 
       - name: Get Keycloak
         run: .github/scripts/prepare-local-server.sh
@@ -91,6 +101,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
 
       - name: Get Keycloak
         run: .github/scripts/prepare-local-server.sh
@@ -106,9 +120,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
       - name: Update maven settings
         run: mkdir -p ~/.m2 ; cp .github/maven-settings.xml ~/.m2/
 

--- a/extension/extend-account-console/src/test/java/org/keycloak/quickstart/ExtendedAccountPage.java
+++ b/extension/extend-account-console/src/test/java/org/keycloak/quickstart/ExtendedAccountPage.java
@@ -9,6 +9,8 @@ import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class ExtendedAccountPage {
 
@@ -51,10 +53,10 @@ public class ExtendedAccountPage {
     }
 
     public boolean isOverviewPage() {
-        return webDriver.getCurrentUrl().endsWith("/sample-overview");
+        return new WebDriverWait(webDriver, 5).until(ExpectedConditions.urlMatches(".*/sample-overview"));
     }
 
     public boolean isKeycloakManPage() {
-        return webDriver.getCurrentUrl().endsWith("/keycloak-man");
+        return new WebDriverWait(webDriver, 5).until(ExpectedConditions.urlMatches(".*/keycloak-man"));
     }
 }

--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:21.1.1
+          image: quay.io/keycloak/keycloak:$$VERSION$$
           args: ["start-dev"]
           env:
             - name: KEYCLOAK_ADMIN

--- a/openshift/keycloak.yaml
+++ b/openshift/keycloak.yaml
@@ -7,7 +7,7 @@ metadata:
     iconClass: icon-sso
     openshift.io/display-name: Keycloak
     tags: keycloak
-    version: 17.0.0-SNAPSHOT
+    version: $$VERSION$$
 objects:
   - apiVersion: v1
     kind: Service

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+NEW_VERSION=$1
+
+mvn versions:set -Dversion.keycloak=$NEW_VERSION -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
+
+sed -i "s|$$VERSION$$|$NEW_VERSION|g" kubernetes/keycloak.yaml
+sed -i "s|$$VERSION$$|$NEW_VERSION|g" openshift/keycloak.yaml

--- a/set-version.sh
+++ b/set-version.sh
@@ -4,5 +4,5 @@ NEW_VERSION=$1
 
 mvn versions:set -Dversion.keycloak=$NEW_VERSION -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
 
-sed -i "s|$$VERSION$$|$NEW_VERSION|g" kubernetes/keycloak.yaml
-sed -i "s|$$VERSION$$|$NEW_VERSION|g" openshift/keycloak.yaml
+sed -i 's|\$\$VERSION\$\$|'$NEW_VERSION'|g' kubernetes/keycloak.yaml
+sed -i 's|\$\$VERSION\$\$|'$NEW_VERSION'|g' openshift/keycloak.yaml


### PR DESCRIPTION
- Fix issues with Keycloak not starting for Node.js and JS tests, and output logs if it fails to start (#451)
- Revert set-version script used by releases (#454)
- Fix version template in Kubernetes and OpenShift templates (#458)
- Wait for the page to load in ExtendedAccountPage
- Fix set-version script for kubernetes and openshift templates
