### PR TITLE
Fix sed command to escape $

### DIFF
--- a/openshift/keycloak.yaml
+++ b/openshift/keycloak.yaml
@@ -65,7 +65,7 @@ objects:
                   value: '${KEYCLOAK_ADMIN_PASSWORD}'
                 - name: KC_PROXY
                   value: 'edge'
-              image: quay.io/keycloak/keycloak:21.1.1
+              image: quay.io/keycloak/keycloak:$$VERSION$$
               livenessProbe:
                 failureThreshold: 100
                 httpGet:

--- a/set-version.sh
+++ b/set-version.sh
@@ -4,5 +4,5 @@ NEW_VERSION=$1
 
 mvn versions:set -Dversion.keycloak=$NEW_VERSION -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
 
-sed -i 's|\$\$VERSION\$\$|'$NEW_VERSION'|g' kubernetes/keycloak.yaml
-sed -i 's|\$\$VERSION\$\$|'$NEW_VERSION'|g' openshift/keycloak.yaml
+sed -i 's/\$\$VERSION\$\$/'"$NEW_VERSION"'/g' kubernetes/keycloak.yaml
+sed -i 's/\$\$VERSION\$\$/'"$NEW_VERSION"'/g' openshift/keycloak.yaml


### PR DESCRIPTION
Reason for PR:
- Currently, the [getting started with kubernetes guide](https://www.keycloak.org/getting-started/getting-started-kube) does not have instructions asking the user to replace the placeholder `$$VERSION$$`.
- Following the instructions listed will result in InvalidImageName error on the pod as it will try to pull `quay.io/keycloak/keycloak:$$VERSION$$`
- https://github.com/keycloak/keycloak-quickstarts/issues/503 

PR Description:
- Fixes the sed command in the set-version.sh script to properly escape $ characters.
- Ensures `$$VERSION$$` placeholder in Kubernetes and OpenShift YAML files is correctly replaced with the provided new version.
- Modifies openshift yaml file to use `$$VERSION$$` instead of a hardcoded value.