### PR TITLE
fix typos in readme: links to getting started

### DIFF
--- a/extension/action-token-authenticator/pom.xml
+++ b/extension/action-token-authenticator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/action-token-required-action/pom.xml
+++ b/extension/action-token-required-action/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/event-listener-sysout/pom.xml
+++ b/extension/event-listener-sysout/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/event-store-mem/pom.xml
+++ b/extension/event-store-mem/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-quickstart-parent</artifactId>
         <groupId>org.keycloak.quickstarts</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/extend-account-console/pom.xml
+++ b/extension/extend-account-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extension/user-storage-jpa/pom.xml
+++ b/extension/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extension/user-storage-simple/pom.xml
+++ b/extension/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/jaxrs-resource-server/README.md
+++ b/jakarta/jaxrs-resource-server/README.md
@@ -27,7 +27,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/jakarta/jaxrs-resource-server/pom.xml
+++ b/jakarta/jaxrs-resource-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/servlet-authz-client/README.md
+++ b/jakarta/servlet-authz-client/README.md
@@ -40,7 +40,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/jakarta/servlet-authz-client/pom.xml
+++ b/jakarta/servlet-authz-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>jakarta-servlet-authz-client</artifactId>

--- a/jakarta/servlet-saml-service-provider/README.md
+++ b/jakarta/servlet-saml-service-provider/README.md
@@ -26,7 +26,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/jakarta/servlet-saml-service-provider/pom.xml
+++ b/jakarta/servlet-saml-service-provider/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/js/spa/README.md
+++ b/js/spa/README.md
@@ -27,7 +27,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -8,7 +8,7 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
+    "@keycloak/keycloak-admin-client": "23.0.3",
     "express": "^4.18.2",
     "string-replace-middleware": "^1.0.2"
   },

--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:$$VERSION$$
+          image: quay.io/keycloak/keycloak:23.0.3
           args: ["start-dev"]
           env:
             - name: KEYCLOAK_ADMIN

--- a/nodejs/resource-server/README.md
+++ b/nodejs/resource-server/README.md
@@ -31,7 +31,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/nodejs/resource-server/package.json
+++ b/nodejs/resource-server/package.json
@@ -8,9 +8,9 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
+    "@keycloak/keycloak-admin-client": "23.0.3",
     "express": "^4.18.2",
-    "keycloak-connect": "https://github.com/keycloak/keycloak-nodejs-connect/releases/download/nightly/keycloak-nodejs-connect.tgz"
+    "keycloak-connect": "23.0.3"
   },
   "devDependencies": {
     "keycloak-request-token": "^0.1.0"

--- a/openshift/keycloak.yaml
+++ b/openshift/keycloak.yaml
@@ -7,7 +7,7 @@ metadata:
     iconClass: icon-sso
     openshift.io/display-name: Keycloak
     tags: keycloak
-    version: $$VERSION$$
+    version: 23.0.3
 objects:
   - apiVersion: v1
     kind: Service
@@ -65,7 +65,7 @@ objects:
                   value: '${KEYCLOAK_ADMIN_PASSWORD}'
                 - name: KC_PROXY
                   value: 'edge'
-              image: quay.io/keycloak/keycloak:$$VERSION$$
+              image: quay.io/keycloak/keycloak:23.0.3
               livenessProbe:
                 failureThreshold: 100
                 httpGet:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>23.0.3</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/spring/rest-authz-resource-server/README.md
+++ b/spring/rest-authz-resource-server/README.md
@@ -29,7 +29,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/spring/rest-authz-resource-server/pom.xml
+++ b/spring/rest-authz-resource-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>23.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This PR modifies six links to "Keycloak Getting Started guides":

```diff
- [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started
+ [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started)
```
