### PR TITLE
fix appearance of links to getting started in readme

### DIFF
--- a/jakarta/jaxrs-resource-server/README.md
+++ b/jakarta/jaxrs-resource-server/README.md
@@ -27,7 +27,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/jakarta/servlet-authz-client/README.md
+++ b/jakarta/servlet-authz-client/README.md
@@ -40,7 +40,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/jakarta/servlet-saml-service-provider/README.md
+++ b/jakarta/servlet-saml-service-provider/README.md
@@ -26,7 +26,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/js/spa/README.md
+++ b/js/spa/README.md
@@ -27,7 +27,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/nodejs/resource-server/README.md
+++ b/nodejs/resource-server/README.md
@@ -31,7 +31,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \

--- a/spring/rest-authz-resource-server/README.md
+++ b/spring/rest-authz-resource-server/README.md
@@ -29,7 +29,7 @@ To compile and run this quickstart you will need:
 Starting and Configuring the Keycloak Server
 -------------------
 
-To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started. For example when using Docker just run the following command in the root directory of this quickstart:
+To start a Keycloak Server you can use OpenJDK on Bare Metal, Docker, Openshift or any other option described in [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started). For example when using Docker just run the following command in the root directory of this quickstart:
 
 ```shell
 docker run --name keycloak \


### PR DESCRIPTION
This PR modifies six links to "Keycloak Getting Started guides":

```diff
- [Keycloak Getting Started guides]https://www.keycloak.org/guides#getting-started
+ [Keycloak Getting Started guides](https://www.keycloak.org/guides#getting-started)
```