### PR TITLE
Replace KC_URL also in keycloak.json

### DIFF
--- a/js/spa/app.js
+++ b/js/spa/app.js
@@ -4,9 +4,13 @@ import stringReplace from 'string-replace-middleware';
 const app = express();
 const port = 8080;
 
+const options = {
+  contentTypeFilterRegexp: /.*/,
+}
+
 app.use(stringReplace({
-  KC_URL: process.env.KC_URL || "http://localhost:8180"
-}));
+  "${KC_URL}": process.env.KC_URL || "http://localhost:8180"
+}, options));
 
 app.use('/', express.static('public'));
 

--- a/js/spa/public/index.html
+++ b/js/spa/public/index.html
@@ -15,7 +15,7 @@
       <h2 id="name"></h2>
       <pre id="output"></pre>
     </div>
-    <script src="KC_URL/js/keycloak.js"></script>
+    <script src="${KC_URL}/js/keycloak.js"></script>
     <script type="module">
       const outputElement = document.getElementById("output");
       const nameElement = document.getElementById("name");

--- a/js/spa/public/keycloak.json
+++ b/js/spa/public/keycloak.json
@@ -1,6 +1,6 @@
 {
   "realm": "quickstart",
-  "auth-server-url": "http://localhost:8180",
+  "auth-server-url": "${KC_URL}",
   "ssl-required": "external",
   "resource": "spa",
   "public-client": true


### PR DESCRIPTION
It seems by default `keycloak.json` response does not have any content-type set and per docs https://github.com/bfncs/string-replace-middleware?tab=readme-ov-file#configuration [string-replace-middleware](https://github.com/bfncs/string-replace-middleware) does not apply string replacement in such case. 

This PR changes the behavior so also `keycloak.json` gets KC_URL replaced and hence can be use the same way as URL in index.html.

