### PR TITLE
Update keycloak-quickstart to work with artifacts from keycloak-clien…

### DIFF
--- a/extension/extend-account-console/pom.xml
+++ b/extension/extend-account-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>24.0.2</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jakarta/servlet-authz-client/pom.xml
+++ b/jakarta/servlet-authz-client/pom.xml
@@ -48,10 +48,6 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-policy-enforcer</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-common</artifactId>
-        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
 
     <properties>
         <version.keycloak>${project.version}</version.keycloak>
+        <version.keycloak.client>26.0.0-SNAPSHOT</version.keycloak.client>
+
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <jboss-jaxrs-api_2.1_spec>1.0.1.Final</jboss-jaxrs-api_2.1_spec>
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
@@ -77,7 +79,7 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-policy-enforcer</artifactId>
-                <version>${version.keycloak}</version>
+                <version>${version.keycloak.client}</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
@@ -92,17 +94,18 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-client</artifactId>
-                <version>${version.keycloak}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-admin-client-jee</artifactId>
-                <version>${version.keycloak}</version>
+                <version>${version.keycloak.client}</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-test-helper</artifactId>
                 <version>${version.keycloak}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.keycloak</groupId>
+                        <artifactId>keycloak-admin-client-tests</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
@@ -266,6 +269,17 @@
                 <dependency>
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-test-helper</artifactId>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.keycloak</groupId>
+                            <artifactId>keycloak-admin-client-tests</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-admin-client</artifactId>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -463,13 +477,6 @@
                     </dependency>
                     <dependency>
                         <groupId>org.keycloak.bom</groupId>
-                        <artifactId>keycloak-misc-bom</artifactId>
-                        <version>${version.keycloak}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.keycloak.bom</groupId>
                         <artifactId>keycloak-spi-bom</artifactId>
                         <version>${version.keycloak}</version>
                         <type>pom</type>
@@ -509,7 +516,7 @@
                     <dependency>
                         <groupId>org.keycloak</groupId>
                         <artifactId>keycloak-policy-enforcer</artifactId>
-                        <version>${version.keycloak}</version>
+                        <version>${version.keycloak.client}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.keycloak</groupId>
@@ -519,23 +526,11 @@
                     <dependency>
                         <groupId>org.keycloak</groupId>
                         <artifactId>keycloak-admin-client</artifactId>
-                        <version>${version.keycloak}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.keycloak</groupId>
-                        <artifactId>keycloak-admin-client-jee</artifactId>
-                        <version>${version.keycloak}</version>
+                        <version>${version.keycloak.client}</version>
                     </dependency>
                 </dependencies>
             </dependencyManagement>
             <dependencies>
-                <dependency>
-                    <groupId>org.keycloak.bom</groupId>
-                    <artifactId>keycloak-misc-bom</artifactId>
-                    <version>${version.keycloak}</version>
-                    <type>pom</type>
-                    <scope>import</scope>
-                </dependency>
                 <dependency>
                     <groupId>org.keycloak.bom</groupId>
                     <artifactId>keycloak-spi-bom</artifactId>
@@ -562,6 +557,17 @@
                 <dependency>
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-test-helper</artifactId>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.keycloak</groupId>
+                            <artifactId>keycloak-admin-client-tests</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-admin-client</artifactId>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/spring/rest-authz-resource-server/pom.xml
+++ b/spring/rest-authz-resource-server/pom.xml
@@ -68,10 +68,6 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-policy-enforcer</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-core</artifactId>
-        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>


### PR DESCRIPTION
…t repository

closes keycloak/keycloak#31416

This is only draft PR for now as it cannot be merged right now. Few points:
- It requires https://github.com/keycloak/keycloak-client/pull/11 first to be merged in keycloak-client repository
- It uses version `26.0.0-SNAPSHOT` of keycloak-client. This should be either updated to some released version of keycloak-client OR we should make sure that `26.0.0-SNAPSHOT` is available in the snapshot repository, like for instance here https://s01.oss.sonatype.org/content/repositories/snapshots/org/keycloak/keycloak-policy-enforcer/ ,which will probably need setup of nightly builds in keycloak-client repository