### PR TITLE
Remove KC_PROXY for Kubernetes

### DIFF
--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -38,8 +38,8 @@ spec:
               value: "admin"
             - name: KEYCLOAK_ADMIN_PASSWORD
               value: "admin"
-            - name: KC_PROXY
-              value: "edge"
+            - name: KC_HTTP_ENABLED
+              value: "true"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Replaced KC_PROXY with KC_HTTP_ENABLED for Kubernetes

Closes #557