### PR TITLE
Health Probe for Kubernetes

### DIFF
--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -40,10 +40,12 @@ spec:
               value: "admin"
             - name: KC_PROXY
               value: "edge"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
           ports:
             - name: http
               containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /realms/master
-              port: 8080
+              path: /health/ready
+              port: 9000


### PR DESCRIPTION
Updated Kubernetes quickstart to use the health endpoint for the readiness probe.

Closes #590