### PR TITLE
Use Keycloak JS from NPM instead of server

### DIFF
--- a/js/spa/app.js
+++ b/js/spa/app.js
@@ -1,14 +1,13 @@
 import express from 'express';
-import stringReplace from 'string-replace-middleware';
 
 const app = express();
 const port = 8080;
 
-app.use(stringReplace({
-  KC_URL: process.env.KC_URL || "http://localhost:8180"
-}));
-
 app.use('/', express.static('public'));
+
+app.use('/vendor/keycloak-js', express.static('node_modules/keycloak-js/dist'));
+app.use('/vendor/jwt-decode', express.static('node_modules/jwt-decode/build/esm'));
+app.use('/vendor/@noble/hashes', express.static('node_modules/@noble/hashes/esm'));
 
 app.listen(port, () => {
   console.log(`Listening on port ${port}.`);

--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
     "express": "^4.18.2",
-    "string-replace-middleware": "^1.0.2"
+    "keycloak-js": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-js-999.0.0-SNAPSHOT.tgz"
   },
   "devDependencies": {
     "@playwright/test": "^1.33.0"

--- a/js/spa/public/index.html
+++ b/js/spa/public/index.html
@@ -3,6 +3,22 @@
   <head>
     <meta charset="utf-8">
     <title>Keycloak Single-Page Application Example</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "keycloak-js": "/vendor/keycloak-js/keycloak.mjs",
+          "jwt-decode": "/vendor/jwt-decode/index.js",
+          "@noble/hashes/sha256": "/vendor/@noble/hashes/sha256.js",
+          "@noble/hashes/crypto": "/vendor/@noble/hashes/crypto.js"
+        }
+      }
+    </script>
+    <link rel="modulepreload" href="/vendor/keycloak-js/keycloak.mjs">
+    <link rel="modulepreload" href="/vendor/jwt-decode/index.js">
+    <link rel="modulepreload" href="/vendor/@noble/hashes/sha256.js">
+    <link rel="modulepreload" href="/vendor/@noble/hashes/_md.js">
+    <link rel="modulepreload" href="/vendor/@noble/hashes/utils.js">
+    <link rel="modulepreload" href="/vendor/@noble/hashes/crypto.js">
   </head>
   <body>
     <div id="user" style="display: none;">
@@ -15,8 +31,9 @@
       <h2 id="name"></h2>
       <pre id="output"></pre>
     </div>
-    <script src="KC_URL/js/keycloak.js"></script>
     <script type="module">
+      import Keycloak from "keycloak-js";
+
       const outputElement = document.getElementById("output");
       const nameElement = document.getElementById("name");
       const userElement = document.getElementById("user");

--- a/set-version.sh
+++ b/set-version.sh
@@ -25,6 +25,7 @@ fi
 
 # JS quickstart
 updateNpmDep js/spa/package.json "@keycloak/keycloak-admin-client"
+updateNpmDep js/spa/package.json "keycloak-js"
 
 # NodeJS quickstart
 updateNpmDep nodejs/resource-server/package.json "@keycloak/keycloak-admin-client"


### PR DESCRIPTION
Replaces the code to load Keycloak JS from the server with the version installed through NPM. This is needed in order to seperate Keycloak JS from the Keycloak server distribution in the future.

Closes #600