### PR TITLE
Update Keycloak JS to use new import path

### DIFF
--- a/js/spa/app.js
+++ b/js/spa/app.js
@@ -1,14 +1,16 @@
 import express from 'express';
+import url from 'node:url';
 
 const app = express();
 const port = 8080;
 
 app.use('/', express.static('public'));
-
-app.use('/vendor/keycloak-js', express.static('node_modules/keycloak-js/dist'));
-app.use('/vendor/jwt-decode', express.static('node_modules/jwt-decode/build/esm'));
-app.use('/vendor/@noble/hashes', express.static('node_modules/@noble/hashes/esm'));
+app.use('/vendor/keycloak.js', express.static(resolveDependency('keycloak-js')));
 
 app.listen(port, () => {
   console.log(`Listening on port ${port}.`);
 });
+
+function resolveDependency(module) {
+  return url.fileURLToPath(import.meta.resolve(module));
+}

--- a/js/spa/public/index.html
+++ b/js/spa/public/index.html
@@ -6,19 +6,11 @@
     <script type="importmap">
       {
         "imports": {
-          "keycloak-js": "/vendor/keycloak-js/keycloak.mjs",
-          "jwt-decode": "/vendor/jwt-decode/index.js",
-          "@noble/hashes/sha256": "/vendor/@noble/hashes/sha256.js",
-          "@noble/hashes/crypto": "/vendor/@noble/hashes/crypto.js"
+          "keycloak-js": "/vendor/keycloak.js"
         }
       }
     </script>
-    <link rel="modulepreload" href="/vendor/keycloak-js/keycloak.mjs">
-    <link rel="modulepreload" href="/vendor/jwt-decode/index.js">
-    <link rel="modulepreload" href="/vendor/@noble/hashes/sha256.js">
-    <link rel="modulepreload" href="/vendor/@noble/hashes/_md.js">
-    <link rel="modulepreload" href="/vendor/@noble/hashes/utils.js">
-    <link rel="modulepreload" href="/vendor/@noble/hashes/crypto.js">
+    <link rel="modulepreload" href="/vendor/keycloak.js">
   </head>
   <body>
     <div id="user" style="display: none;">
@@ -83,7 +75,12 @@
           await keycloak.accountManagement()
         });
 
-      const keycloak = new Keycloak();
+      const keycloak = new Keycloak({
+        url: "http://localhost:8180",
+        realm: "quickstart",
+        clientId: "spa",
+      });
+
       await keycloak.init({ onLoad: "login-required" });
       showProfile();
     </script>

--- a/js/spa/public/keycloak.json
+++ b/js/spa/public/keycloak.json
@@ -1,7 +1,0 @@
-{
-  "realm": "quickstart",
-  "auth-server-url": "http://localhost:8180",
-  "ssl-required": "external",
-  "resource": "spa",
-  "public-client": true
-}


### PR DESCRIPTION
Adjusts the import to Keycloak JS to use the new import path by letting Node.js resolve the module location. This also removes the `keycloak.json` configuration and passes the configuration directly to the instance instead.

Closes #607