### PR TITLE
UPDATE: deprecated env variables.

### DIFF
--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -34,12 +34,12 @@ spec:
           image: quay.io/keycloak/keycloak:26.0.0
           args: ["start-dev"]
           env:
-            - name: KEYCLOAK_ADMIN
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               value: "admin"
-            - name: KEYCLOAK_ADMIN_PASSWORD
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               value: "admin"
-            - name: KC_PROXY
-              value: "edge"
+            - name: KC_PROXY_HEADERS
+              value: "xforwarded"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Update the variables because they are deprecated with v 26

Closes: https://github.com/keycloak/keycloak-quickstarts/issues/557