### PR TITLE
Fix policy-enforcer parsing not replacing system variables

### DIFF
--- a/spring/rest-authz-resource-server/src/main/java/org/keycloak/quickstart/OAuth2ResourceServerSecurityConfiguration.java
+++ b/spring/rest-authz-resource-server/src/main/java/org/keycloak/quickstart/OAuth2ResourceServerSecurityConfiguration.java
@@ -17,11 +17,13 @@ package org.keycloak.quickstart;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.adapters.authorization.integration.jakarta.ServletPolicyEnforcerFilter;
 import org.keycloak.adapters.authorization.spi.ConfigurationResolver;
 import org.keycloak.adapters.authorization.spi.HttpRequest;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.SystemPropertiesJsonParserFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -60,7 +62,9 @@ public class OAuth2ResourceServerSecurityConfiguration {
 		PolicyEnforcerConfig config;
 
 		try {
-			config = JsonSerialization.readValue(getClass().getResourceAsStream("/policy-enforcer.json"), PolicyEnforcerConfig.class);
+			ObjectMapper mapper = new ObjectMapper(new SystemPropertiesJsonParserFactory());
+			mapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+			config = mapper.readValue(getClass().getResourceAsStream("/policy-enforcer.json"), PolicyEnforcerConfig.class);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
This is not strictly necessary for this quickstart itself, however, it might be useful for someone playing with it.

The parsing is taken from:
https://github.com/keycloak/keycloak/blob/213b4ca6d16501e90e69f4055b43199fb445549b/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java#L77-L81