### PR TITLE
Wait for pages to load in SAMLServiceProviderTest

### DIFF
--- a/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/PageHelper.java
+++ b/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/PageHelper.java
@@ -20,7 +20,6 @@ package org.keycloak.quickstart;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.logging.Logger;
-import org.junit.Assert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
@@ -35,6 +34,15 @@ public class PageHelper {
     public boolean isOnStartPage() {
         fixStylesPage();
         return browser.findElements(By.name("loginBtn")).size() > 0;
+    }
+
+    public void waitForStartPage() {
+        fixStylesPage();
+        try {
+            Graphene.waitAjax().until().element(By.name("loginBtn")).is().present();
+        } catch (TimeoutException ex) {
+            throw new TimeoutException("timeout on page " + browser.getCurrentUrl(), ex);
+        }
     }
 
     public void waitForAccountBtn() {
@@ -57,6 +65,22 @@ public class PageHelper {
     public void isOnLoginPage() {
         try {
             Graphene.waitAjax().until().element(By.id("username")).is().present();
+        } catch (TimeoutException ex) {
+            throw new TimeoutException("timeout on page " + browser.getCurrentUrl(), ex);
+        }
+    }
+
+    public void waitForLoginPage() {
+        try {
+            Graphene.waitAjax().until().element(By.id("username")).is().present();
+        } catch (TimeoutException ex) {
+            throw new TimeoutException("timeout on page " + browser.getCurrentUrl(), ex);
+        }
+    }
+
+    public void waitUntilTitle(String title) {
+        try {
+            Graphene.waitAjax().until((WebDriver driver) -> driver.getTitle().contains(title));
         } catch (TimeoutException ex) {
             throw new TimeoutException("timeout on page " + browser.getCurrentUrl(), ex);
         }

--- a/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/SAMLServiceProviderTest.java
+++ b/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/SAMLServiceProviderTest.java
@@ -108,6 +108,7 @@ public class SAMLServiceProviderTest {
     public void testLogin() {
         try {
             indexPage.clickLogin();
+            pageHelper.waitForLoginPage();
             loginPage.login("alice", "alice");
             // due to https://issues.redhat.com/browse/KEYCLOAK-14103 a second click to login is required
             // need to upgrade to Wildfly 19.1.0 to support a solution to this
@@ -118,9 +119,9 @@ public class SAMLServiceProviderTest {
             pageHelper.waitForAccountBtn();
             assertEquals(profilePage.getUsername(), "alice");
             profilePage.clickLogout();
-            assertTrue(pageHelper.isOnStartPage());
+            pageHelper.waitForStartPage();
             indexPage.clickLogin();
-            pageHelper.isOnLoginPage();
+            pageHelper.waitForLoginPage();
         } catch (Exception e) {
             debugTest(e);
             fail("Should display logged in user");
@@ -131,6 +132,7 @@ public class SAMLServiceProviderTest {
     public void testAccessAccountManagement() {
         try {
             indexPage.clickLogin();
+            pageHelper.waitForLoginPage();
             loginPage.login("alice", "alice");
             // due to https://issues.redhat.com/browse/KEYCLOAK-14103 a second click to login is required
             // need to upgrade to Wildfly 19.1.0 to support a solution to this
@@ -140,7 +142,7 @@ public class SAMLServiceProviderTest {
             }
             pageHelper.waitForAccountBtn();
             profilePage.clickAccount();
-            assertTrue(webDriver.getTitle().contains("Account Management"));
+            pageHelper.waitUntilTitle("Account Management");
         } catch (Exception e) {
             debugTest(e);
             fail("Should display account management page");


### PR DESCRIPTION
Closes #609

The pR just waits instead of check for pages directly. For example check this [CI output](https://github.com/rmartinc/keycloak-quickstarts/actions/runs/11893749304/job/33139422220) with 10 passes. I have executed it 30 times with no issues.