### PR TITLE
Create workflow to test quickstarts with nightly keycloak/keycloak-client

### DIFF
--- a/.github/scripts/prepare-local-server.sh
+++ b/.github/scripts/prepare-local-server.sh
@@ -2,13 +2,15 @@
 
 mkdir keycloak-dist
 
-if [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n "$QUICKSTART_BRANCH" && "$QUICKSTART_BRANCH" != "main" ) ]]; then
-  VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
-  echo "Using corresponding Keycloak version: $VERSION"
-  URL="https://github.com/keycloak/keycloak/releases/download/${VERSION}/keycloak-${VERSION}.tar.gz"
-else
-  echo "Downloading nightly Keycloak release"
+if [ "$NIGHTLY_TEST" == "true" ]; then
+  # the nighly version is used
+  echo "Downloading Keycloak release nightly"
   URL="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.tar.gz"
+else
+  # normal execution with current keycloak versions
+  VERSION=$(grep -oPm1 "(?<=<version.keycloak>)[^<]+" pom.xml)
+  echo "Downloading Keycloak release $VERSION"
+  URL="https://github.com/keycloak/keycloak/releases/download/${VERSION}/keycloak-${VERSION}.tar.gz"
 fi
 
 wget -q -O keycloak-dist.tar.gz "$URL"

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -28,6 +28,12 @@ run_tests() {
   else
     args="$args -Dwebdriver.chrome.driver=/usr/local/bin/chromedriver"
   fi
+  if [ -n "$KEYCLOAK_VERSION" ]; then
+    args="$args -Dversion.keycloak=$KEYCLOAK_VERSION"
+  fi
+  if [ -n "$KEYCLOAK_CLIENT_VERSION" ]; then
+    args="$args -Dversion.keycloak.client=$KEYCLOAK_CLIENT_VERSION"
+  fi
   args="$args -D$module"
   log_file=${module////_}.log
   if ! mvn clean install -Dnightly $args -B 2>&1 | tee test-logs/$log_file; then
@@ -50,10 +56,9 @@ print_failed_tests() {
   fi
 }
 
-if [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n "$QUICKSTART_BRANCH" && "$QUICKSTART_BRANCH" != "main" ) ]]; then
-  export KEYCLOAK_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-else
+if [ "$NIGHTLY_TEST" == "true" ]; then
   export KEYCLOAK_VERSION="999.0.0-SNAPSHOT"
+  export KEYCLOAK_CLIENT_VERSION="999.0.0-SNAPSHOT"
 fi
 
 if [ -n "$KEYCLOAK_VERSION" ]; then

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,4 +1,4 @@
-name: Keycloak Integration CI
+name: Keycloak Integration CI Nightly
 
 on:
   push:
@@ -9,3 +9,5 @@ jobs:
 
   call-ci-workflow:
     uses: ./.github/workflows/workflow-ci.yml
+    with:
+      nightly-test: 'true'

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -15,3 +15,12 @@ jobs:
         if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-quickstarts'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  run-nightly-ci:
+    name: Run Nightly CI workflow
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run -R keycloak/keycloak-quickstarts nightly-ci.yml -r main
+        if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-quickstarts'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -1,0 +1,152 @@
+name: Reusable Keycloak Integration CI
+
+on:
+  workflow_call:
+    inputs:
+      nightly-test:
+        description: 'if true nightly 999.0.0-SNAPSHOT version is used for keycloak and keycloak-client, otherwise the current versions in pom.xml'
+        default: 'false'
+        required: false
+        type: string
+
+env:
+  DEFAULT_JDK_VERSION: 17
+  DEFAULT_JDK_DIST: temurin
+  NIGHTLY_TEST: ${{ inputs.nightly-test }}
+
+jobs:
+
+  tests:
+    name: Jakarta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
+      - name: Update maven settings
+        run: mkdir -p ~/.m2 ; cp .github/maven-settings.xml ~/.m2/
+
+      - name: Cache Maven repo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/keycloak
+          key: cache-1-${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: cache-1-${{ runner.os }}-m2
+
+      - name: Get Keycloak
+        run: .github/scripts/prepare-local-server.sh
+
+      - name: Start Keycloak
+        run: .github/scripts/start-local-server.sh
+
+      - name: Run unit tests
+        run: .github/scripts/run-tests.sh jakarta
+
+  tests-spring:
+    name: Spring
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
+      - name: Update maven settings
+        run: mkdir -p ~/.m2 ; cp .github/maven-settings.xml ~/.m2/
+
+      - name: Cache Maven repo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/keycloak
+          key: cache-1-${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: cache-1-${{ runner.os }}-m2
+
+      - name: Get Keycloak
+        run: .github/scripts/prepare-local-server.sh
+
+      - name: Start Keycloak
+        run: .github/scripts/start-local-server.sh
+
+      - name: Run unit tests
+        run: .github/scripts/run-tests.sh spring
+
+  tests-nodejs:
+    name: Node.js
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
+
+      - name: Get Keycloak
+        run: .github/scripts/prepare-local-server.sh
+
+      - name: Start Keycloak
+        run: .github/scripts/start-local-server.sh
+
+      - name: Run unit tests
+        run: .github/scripts/run-tests.sh nodejs
+
+  tests-js:
+    name: JavaScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
+
+      - name: Get Keycloak
+        run: .github/scripts/prepare-local-server.sh
+
+      - name: Start Keycloak
+        run: .github/scripts/start-local-server.sh
+
+      - name: Run unit tests
+        run: .github/scripts/run-tests.sh js
+
+  tests-extension:
+    name: Extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.DEFAULT_JDK_DIST }}
+          java-version: ${{ env.DEFAULT_JDK_VERSION }}
+      - name: Update maven settings
+        run: mkdir -p ~/.m2 ; cp .github/maven-settings.xml ~/.m2/
+
+      - name: Cache Maven repo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/keycloak
+          key: cache-1-${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: cache-1-${{ runner.os }}-m2
+
+      - name: Get Keycloak
+        run: .github/scripts/prepare-local-server.sh
+
+      - name: Start Keycloak
+        run: .github/scripts/start-local-server.sh extension
+
+      - name: Run unit tests
+        run: .github/scripts/run-tests.sh extension
+

--- a/jakarta/servlet-authz-client/pom.xml
+++ b/jakarta/servlet-authz-client/pom.xml
@@ -33,10 +33,6 @@
         </license>
     </licenses>
 
-    <properties>
-        <version.keycloak>${project.version}</version.keycloak>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
                                         <feature-pack>
                                             <groupId>org.keycloak</groupId>
                                             <artifactId>keycloak-saml-adapter-galleon-pack</artifactId>
-                                            <version>${project.version}</version>
+                                            <version>${version.keycloak}</version>
                                         </feature-pack>
                                     </feature-packs>
                                     <pluginOptions>


### PR DESCRIPTION
Closes [#35439](https://github.com/keycloak/keycloak/issues/35439)

I have used the sonatype-snapshots repository to do the tests with nightly. The repo is already used in the quickstarts so I think that it's better this way. The scripts use a environment variable `NIGHTLY_TEST` to use nightly versions 999.0.0-SNAPSHOT instead of the current versions defined in the `pom.xml`. The CI file is transformed into a re-usable workflow called `worflow-ci.yml`. This is called by another two workflows: `ci.yml` (which tests current versions defined in `pom.xml`) and `nightly-ci.yml` (it tests the nightly versions). I have setup to run both at pull, similar to what we do in the keycloak-client repo, but we can execute the nightly CI scheduled at night if preferred. I have also changed some versions because they were using fixed versions (now depend on the var, nightly or current). It's a draft for the moment.