### PR TITLE
Add Secret Question authenticator back

### DIFF
--- a/extension/authenticator/README.md
+++ b/extension/authenticator/README.md
@@ -1,0 +1,64 @@
+authenticator: Example custom authenticator
+========================================================
+
+Level: Beginner  
+Summary: Example custom authenticator  
+Target Product: <span>Keycloak</span>  
+Source: <https://github.com/keycloak/keycloak-quickstarts>
+
+
+What is it?
+-----------
+
+This is an example of the Authenticator SPI implemented a custom authenticator. It allows the user to create a secret
+question that is prompted when a user logs in to a new machine. The example does not aim to provide a realistic 
+authentication mechanisms and should not be leveraged in production.
+
+
+System Requirements
+-------------------
+
+You need to have <span>Keycloak</span> running. It is recommended to use Keycloak 24 or later.
+
+All you need to build this project is Java 17 (Java SDK 17) or later and Maven 3.6.3 or later.
+
+Build and Deploy the Quickstart
+-------------------------------
+
+To build the provider, run the following maven command:
+
+   ````
+   mvn -Pextension clean install -DskipTests=true
+   ````
+
+To install the provider, copy the target/authenticator-example.jar file to the `providers` directory of the server distribution.
+
+Finally, start the server as follows:
+
+    kc.[sh|bat] start-dev
+
+Enable the Provider for a Realm
+-------------------------------
+It is not recommended to try this out with the master realm, so either use an existing test realm or create a new one.
+If you create a new realm you must also register at least one user in the realm.
+
+To enable the custom authenticator the first step is to create a custom authentication flow where it can be registered.
+Login to the <span>Keycloak</span> Admin Console and got to the Authentication tab. Select the `browser` flow and under
+`Action` click on `Duplicate`. Leave the name and description as is, and click on `Duplicate` to create the custom 
+authentication flow.
+
+Next step is to add the authenticator to the custom flow. On the row named `Copy of browser forms` click on the '+'
+symbol and select `Add step`. Enter `secret` in the search box to find the custom authenticator. Select `Secret question`
+and click `Add`. When added it will not be required initially, so find the row for `Secret Questions` and change
+the requirement to `Required`.
+
+Next step is to bind the custom flow as the default browser flow. Click on `Action` and select `Bind flow`, 
+choose the binding type `Browser flow` and click on `Save`.
+
+Final step is to enable the required action that is used by users to enter the answer needed to login. Click on
+`Authentication` then on `Required actions`. Next to `Secret Question` click on the toggle for `Enabled` to turn on
+the required action.
+
+Now everything is configured and ready to try out, and you can try to login to the realm. The first time the user logs
+in the user will be prompted to provide an answer to a question. The user will be prompted the question again when 
+using a new machine or closing the browser.

--- a/extension/authenticator/pom.xml
+++ b/extension/authenticator/pom.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-quickstart-parent</artifactId>
+        <groupId>org.keycloak.quickstarts</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <name>Keycloak Quickstart: Authenticator Example</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>authenticator-example</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>${version.keycloak}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>authenticator-example</finalName>
+    </build>
+</project>

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.CredentialValidator;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.models.UserModel;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionAuthenticator implements Authenticator, CredentialValidator<SecretQuestionCredentialProvider> {
+
+    protected boolean hasCookie(AuthenticationFlowContext context) {
+        Cookie cookie = context.getHttpRequest().getHttpHeaders().getCookies().get("SECRET_QUESTION_ANSWERED");
+        boolean result = cookie != null;
+        if (result) {
+            System.out.println("Bypassing secret question because cookie is set");
+        }
+        return result;
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        if (hasCookie(context)) {
+            context.success();
+            return;
+        }
+        Response challenge = context.form()
+                .createForm("secret-question.ftl");
+        context.challenge(challenge);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        boolean validated = validateAnswer(context);
+        if (!validated) {
+            Response challenge =  context.form()
+                    .setError("badSecret")
+                    .createForm("secret-question.ftl");
+            context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challenge);
+            return;
+        }
+        setCookie(context);
+        context.success();
+    }
+
+    protected void setCookie(AuthenticationFlowContext context) {
+        AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+        int maxCookieAge = 60 * 60 * 24 * 30; // 30 days
+        if (config != null) {
+            maxCookieAge = Integer.valueOf(config.getConfig().get("cookie.max.age"));
+
+        }
+        URI uri = context.getUriInfo().getBaseUriBuilder().path("realms").path(context.getRealm().getName()).build();
+
+        NewCookie newCookie = new NewCookie.Builder("SECRET_QUESTION_ANSWERED").value("true")
+                .path(uri.getRawPath())
+                .maxAge(maxCookieAge)
+                .secure(false)
+                .build();
+        context.getSession().getContext().getHttpResponse().setCookieIfAbsent(newCookie);
+    }
+
+    protected boolean validateAnswer(AuthenticationFlowContext context) {
+        MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+        String secret = formData.getFirst("secret_answer");
+        String credentialId = formData.getFirst("credentialId");
+        if (credentialId == null || credentialId.isEmpty()) {
+            credentialId = getCredentialProvider(context.getSession())
+                    .getDefaultCredential(context.getSession(), context.getRealm(), context.getUser()).getId();
+        }
+
+        UserCredentialModel input = new UserCredentialModel(credentialId, getType(context.getSession()), secret);
+        return getCredentialProvider(context.getSession()).isValid(context.getRealm(), context.getUser(), input);
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return true;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return getCredentialProvider(session).isConfiguredFor(realm, user, getType(session));
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        user.addRequiredAction(SecretQuestionRequiredAction.PROVIDER_ID);
+    }
+
+    public List<RequiredActionFactory> getRequiredActions(KeycloakSession session) {
+        return Collections.singletonList((SecretQuestionRequiredActionFactory)session.getKeycloakSessionFactory().getProviderFactory(RequiredActionProvider.class, SecretQuestionRequiredAction.PROVIDER_ID));
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public SecretQuestionCredentialProvider getCredentialProvider(KeycloakSession session) {
+        return (SecretQuestionCredentialProvider)session.getProvider(CredentialProvider.class, SecretQuestionCredentialProviderFactory.PROVIDER_ID);
+    }
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticatorFactory.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticatorFactory.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.ConfigurableAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionAuthenticatorFactory implements AuthenticatorFactory, ConfigurableAuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "secret-question-authenticator";
+    private static final SecretQuestionAuthenticator SINGLETON = new SecretQuestionAuthenticator();
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    private static AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+            AuthenticationExecutionModel.Requirement.DISABLED
+    };
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return true;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty();
+        property.setName("cookie.max.age");
+        property.setLabel("Cookie Max Age");
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setHelpText("Max age in seconds of the SECRET_QUESTION_COOKIE.");
+        configProperties.add(property);
+    }
+
+
+    @Override
+    public String getHelpText() {
+        return "A secret question that a user has to answer. i.e. What is your mother's maiden name.";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Secret Question";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "Secret Question";
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProvider.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.examples.authenticator;
+
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialInputValidator;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.CredentialTypeMetadata;
+import org.keycloak.credential.CredentialTypeMetadataContext;
+import org.keycloak.examples.authenticator.credential.SecretQuestionCredentialModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionCredentialProvider implements CredentialProvider<SecretQuestionCredentialModel>, CredentialInputValidator {
+    private static final Logger logger = Logger.getLogger(SecretQuestionCredentialProvider.class);
+
+    protected KeycloakSession session;
+
+    public SecretQuestionCredentialProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {
+        if (!(input instanceof UserCredentialModel)) {
+            logger.debug("Expected instance of UserCredentialModel for CredentialInput");
+            return false;
+        }
+        if (!input.getType().equals(getType())) {
+            return false;
+        }
+        String challengeResponse = input.getChallengeResponse();
+        if (challengeResponse == null) {
+            return false;
+        }
+        CredentialModel credentialModel = user.credentialManager().getStoredCredentialById(input.getCredentialId());
+        SecretQuestionCredentialModel sqcm = getCredentialFromModel(credentialModel);
+        return sqcm.getSecretQuestionSecretData().getAnswer().equals(challengeResponse);
+    }
+
+    @Override
+    public boolean supportsCredentialType(String credentialType) {
+        return getType().equals(credentialType);
+    }
+
+    @Override
+    public boolean isConfiguredFor(RealmModel realm, UserModel user, String credentialType) {
+        if (!supportsCredentialType(credentialType)) return false;
+        return user.credentialManager().getStoredCredentialsByTypeStream(credentialType).findAny().isPresent();
+    }
+
+    @Override
+    public CredentialModel createCredential(RealmModel realm, UserModel user, SecretQuestionCredentialModel credentialModel) {
+        if (credentialModel.getCreatedDate() == null) {
+            credentialModel.setCreatedDate(Time.currentTimeMillis());
+        }
+        return user.credentialManager().createStoredCredential(credentialModel);
+    }
+
+    @Override
+    public boolean deleteCredential(RealmModel realm, UserModel user, String credentialId) {
+        return user.credentialManager().removeStoredCredentialById(credentialId);
+    }
+
+    @Override
+    public SecretQuestionCredentialModel getCredentialFromModel(CredentialModel model) {
+        return SecretQuestionCredentialModel.createFromCredentialModel(model);
+    }
+
+    @Override
+    public CredentialTypeMetadata getCredentialTypeMetadata(CredentialTypeMetadataContext metadataContext) {
+        return CredentialTypeMetadata.builder()
+                .type(getType())
+                .category(CredentialTypeMetadata.Category.TWO_FACTOR)
+                .displayName(SecretQuestionCredentialProviderFactory.PROVIDER_ID)
+                .helpText("secret-question-text")
+                .createAction(SecretQuestionAuthenticatorFactory.PROVIDER_ID)
+                .removeable(false)
+                .build(session);
+    }
+
+    @Override
+    public String getType() {
+        return SecretQuestionCredentialModel.TYPE;
+    }
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProviderFactory.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProviderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.examples.authenticator;
+
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.CredentialProviderFactory;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionCredentialProviderFactory implements CredentialProviderFactory<SecretQuestionCredentialProvider> {
+
+    public static final String PROVIDER_ID =  "secret-question";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public CredentialProvider create(KeycloakSession session) {
+        return new SecretQuestionCredentialProvider(session);
+    }
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredAction.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredAction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator;
+
+import org.keycloak.authentication.CredentialRegistrator;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.examples.authenticator.credential.SecretQuestionCredentialModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionRequiredAction implements RequiredActionProvider, CredentialRegistrator {
+    public static final String PROVIDER_ID = "secret_question_config";
+
+    @Override
+    public void evaluateTriggers(RequiredActionContext context) {
+
+    }
+
+    @Override
+    public String getCredentialType(KeycloakSession session, AuthenticationSessionModel AuthenticationSession) {
+        return SecretQuestionCredentialModel.TYPE;
+    }
+
+    @Override
+    public void requiredActionChallenge(RequiredActionContext context) {
+        Response challenge = context.form().createForm("secret-question-config.ftl");
+        context.challenge(challenge);
+
+    }
+
+    @Override
+    public void processAction(RequiredActionContext context) {
+        String answer = (context.getHttpRequest().getDecodedFormParameters().getFirst("secret_answer"));
+        SecretQuestionCredentialProvider sqcp = (SecretQuestionCredentialProvider) context.getSession().getProvider(CredentialProvider.class, "secret-question");
+        sqcp.createCredential(context.getRealm(), context.getUser(), SecretQuestionCredentialModel.createSecretQuestion("What is your mom's first name?", answer));
+        context.success();
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredActionFactory.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredActionFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionRequiredActionFactory implements RequiredActionFactory {
+
+    private static final SecretQuestionRequiredAction SINGLETON = new SecretQuestionRequiredAction();
+
+    @Override
+    public RequiredActionProvider create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+
+    @Override
+    public String getId() {
+        return SecretQuestionRequiredAction.PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayText() {
+        return "Secret Question";
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/SecretQuestionCredentialModel.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/SecretQuestionCredentialModel.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator.credential;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.examples.authenticator.credential.dto.SecretQuestionCredentialData;
+import org.keycloak.examples.authenticator.credential.dto.SecretQuestionSecretData;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionCredentialModel extends CredentialModel {
+    public static final String TYPE = "SECRET_QUESTION";
+
+    private final SecretQuestionCredentialData credentialData;
+    private final SecretQuestionSecretData secretData;
+
+    private SecretQuestionCredentialModel(SecretQuestionCredentialData credentialData, SecretQuestionSecretData secretData) {
+        this.credentialData = credentialData;
+        this.secretData = secretData;
+    }
+
+    private SecretQuestionCredentialModel(String question, String answer) {
+        credentialData = new SecretQuestionCredentialData(question);
+        secretData = new SecretQuestionSecretData(answer);
+    }
+
+    public static SecretQuestionCredentialModel createSecretQuestion(String question, String answer) {
+        SecretQuestionCredentialModel credentialModel = new SecretQuestionCredentialModel(question, answer);
+        credentialModel.fillCredentialModelFields();
+        return credentialModel;
+    }
+
+    public static SecretQuestionCredentialModel createFromCredentialModel(CredentialModel credentialModel){
+        try {
+            SecretQuestionCredentialData credentialData = JsonSerialization.readValue(credentialModel.getCredentialData(), SecretQuestionCredentialData.class);
+            SecretQuestionSecretData secretData = JsonSerialization.readValue(credentialModel.getSecretData(), SecretQuestionSecretData.class);
+
+            SecretQuestionCredentialModel secretQuestionCredentialModel = new SecretQuestionCredentialModel(credentialData, secretData);
+            secretQuestionCredentialModel.setUserLabel(credentialModel.getUserLabel());
+            secretQuestionCredentialModel.setCreatedDate(credentialModel.getCreatedDate());
+            secretQuestionCredentialModel.setType(TYPE);
+            secretQuestionCredentialModel.setId(credentialModel.getId());
+            secretQuestionCredentialModel.setSecretData(credentialModel.getSecretData());
+            secretQuestionCredentialModel.setCredentialData(credentialModel.getCredentialData());
+            return secretQuestionCredentialModel;
+        } catch (IOException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SecretQuestionCredentialData getSecretQuestionCredentialData() {
+        return credentialData;
+    }
+
+    public SecretQuestionSecretData getSecretQuestionSecretData() {
+        return secretData;
+    }
+
+    private void fillCredentialModelFields(){
+        try {
+            setCredentialData(JsonSerialization.writeValueAsString(credentialData));
+            setSecretData(JsonSerialization.writeValueAsString(secretData));
+            setType(TYPE);
+            setCreatedDate(Time.currentTimeMillis());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionCredentialData.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionCredentialData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator.credential.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionCredentialData {
+
+    private final String question;
+
+    @JsonCreator
+    public SecretQuestionCredentialData(@JsonProperty("question") String question) {
+        this.question = question;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+}

--- a/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionSecretData.java
+++ b/extension/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionSecretData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator.credential.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionSecretData {
+
+     private final String answer;
+
+    @JsonCreator
+     public SecretQuestionSecretData(@JsonProperty("answer") String answer) {
+         this.answer = answer;
+     }
+
+    public String getAnswer() {
+        return answer;
+    }
+}

--- a/extension/authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/extension/authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.examples.authenticator.SecretQuestionAuthenticatorFactory

--- a/extension/authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
+++ b/extension/authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.examples.authenticator.SecretQuestionRequiredActionFactory

--- a/extension/authenticator/src/main/resources/META-INF/services/org.keycloak.credential.CredentialProviderFactory
+++ b/extension/authenticator/src/main/resources/META-INF/services/org.keycloak.credential.CredentialProviderFactory
@@ -1,0 +1,1 @@
+ org.keycloak.examples.authenticator.SecretQuestionCredentialProviderFactory

--- a/extension/authenticator/src/main/resources/theme-resources/templates/secret-question-config.ftl
+++ b/extension/authenticator/src/main/resources/theme-resources/templates/secret-question-config.ftl
@@ -1,0 +1,33 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <#if section = "title">
+        ${msg("loginTitle",realm.name)}
+    <#elseif section = "header">
+        Setup Secret Question
+    <#elseif section = "form">
+        <form id="kc-totp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="totp" class="${properties.kcLabelClass!}">What is your mom's first name?</label>
+                </div>
+
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input id="totp" name="secret_answer" type="text" class="${properties.kcInputClass!}" />
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <div class="${properties.kcFormButtonsWrapperClass!}">
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doSubmit")}"/>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/extension/authenticator/src/main/resources/theme-resources/templates/secret-question.ftl
+++ b/extension/authenticator/src/main/resources/theme-resources/templates/secret-question.ftl
@@ -1,0 +1,35 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <#if section = "title">
+        ${msg("loginTitle",realm.name)}
+    <#elseif section = "header">
+        ${msg("loginTitleHtml",realm.name)}
+    <#elseif section = "form">
+        <form id="kc-totp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="totp" class="${properties.kcLabelClass!}">What is your mom's first name</label>
+                </div>
+
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input id="totp" name="secret_answer" type="text" class="${properties.kcInputClass!}" />
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <div class="${properties.kcFormButtonsWrapperClass!}">
+                        <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                               name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak-quickstarts/issues/553

Attempts to add back the "Authenticator SPI walk through" example that is missing. Right now the reference the docs point to does not exist: https://www.keycloak.org/docs/26.0.6/server_development/#_auth_spi_walkthrough

I just cherrypicked stianst's commit that is missing from the `main` branch and added the implementation of `SecretQuestionRequiredAction.getCredentialType`, as per mposolda's comment: https://github.com/keycloak/keycloak-quickstarts/issues/553#issuecomment-2091269100

Tested it locally with keycloak 26.0.6 and it works fine.
Please let me know if I messed anything up with the squash in terms of history/blame.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to the `latest` branch.
-->
