### PR TITLE
Updating set-version.sh and adding set-server-version.sh. Updated server version to 26.0.7

### DIFF
--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -8,9 +8,9 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
+    "@keycloak/keycloak-admin-client": "26.0.7",
     "express": "^4.18.2",
-    "keycloak-js": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-js-999.0.0-SNAPSHOT.tgz"
+    "keycloak-js": "26.0.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.33.0"

--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:$$VERSION$$
+          image: quay.io/keycloak/keycloak:26.0.7
           args: ["start-dev"]
           env:
             - name: KEYCLOAK_ADMIN

--- a/nodejs/resource-server/package.json
+++ b/nodejs/resource-server/package.json
@@ -8,9 +8,9 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
+    "@keycloak/keycloak-admin-client": "26.0.7",
     "express": "^4.18.2",
-    "keycloak-connect": "https://github.com/keycloak/keycloak-nodejs-connect/releases/download/nightly/keycloak-nodejs-connect.tgz"
+    "keycloak-connect": "26.0.7"
   },
   "devDependencies": {
     "keycloak-request-token": "^0.1.0"

--- a/openshift/keycloak.yaml
+++ b/openshift/keycloak.yaml
@@ -7,7 +7,7 @@ metadata:
     iconClass: icon-sso
     openshift.io/display-name: Keycloak
     tags: keycloak
-    version: $$VERSION$$
+    version: 26.0.7
 objects:
   - apiVersion: v1
     kind: Service
@@ -65,7 +65,7 @@ objects:
                   value: '${KEYCLOAK_ADMIN_PASSWORD}'
                 - name: KC_PROXY
                   value: 'edge'
-              image: quay.io/keycloak/keycloak:$$VERSION$$
+              image: quay.io/keycloak/keycloak:26.0.7
               livenessProbe:
                 failureThreshold: 100
                 httpGet:

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </licenses>
 
     <properties>
-        <version.keycloak>26.0.6</version.keycloak>
+        <version.keycloak>26.0.7</version.keycloak>
         <version.keycloak.client>26.0.3</version.keycloak.client>
 
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>

--- a/set-server-version.sh
+++ b/set-server-version.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+NEW_VERSION=$1
+
+function updateNpmDep() {
+  FILE="$1"
+  PACKAGE="$2"
+
+  sed -i 's|"'"$PACKAGE"'": "[^"]*"|"'"$PACKAGE"'": "'"$NEW_VERSION"'"|g' $FILE
+}
+
+mvn versions:set-property -Dproperty=version.keycloak -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false
+
+sed -i 's/ image:\(.*\):.*/ image:\1:'"$NEW_VERSION"'/g' kubernetes/keycloak.yaml
+sed -i 's/ version: .*/ version: '"$NEW_VERSION"'/g' openshift/keycloak.yaml
+sed -i 's/ image:\(.*\):.*/ image:\1:'"$NEW_VERSION"'/g' openshift/keycloak.yaml
+
+if [[ $NEW_VERSION == "999.0.0-SNAPSHOT" ]]; then
+  # Use the nightly versions of adapters
+  NPM_ADMIN_CLIENT="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz"
+  NPM_NODE_ADAPTER="https://github.com/keycloak/keycloak-nodejs-connect/releases/download/nightly/keycloak-nodejs-connect.tgz";
+else
+  NPM_ADMIN_CLIENT=$NEW_VERSION
+  NPM_NODE_ADAPTER=$NEW_VERSION
+fi
+
+# JS quickstart
+updateNpmDep js/spa/package.json "@keycloak/keycloak-admin-client"
+updateNpmDep js/spa/package.json "keycloak-js"
+
+# NodeJS quickstart
+updateNpmDep nodejs/resource-server/package.json "@keycloak/keycloak-admin-client"
+updateNpmDep nodejs/resource-server/package.json "keycloak-connect"
+
+echo "New Mvn Version: $NEW_VERSION" >&2
+echo "Used NPM dependency of keycloak-admin-client: $NPM_ADMIN_CLIENT" >&2
+echo "Used NPM dependency of node-adapter: $NPM_NODE_ADAPTER" >&2

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,36 +1,7 @@
 #!/bin/bash -e
 
+# Sets new version of the project in all pom.xml files
+
 NEW_VERSION=$1
 
-function updateNpmDep() {
-  FILE="$1"
-  PACKAGE="$2"
-
-  sed -i 's|"'"$PACKAGE"'": "[^"]*"|"'"$PACKAGE"'": "'"$NEW_VERSION"'"|g' $FILE
-}
-
-mvn versions:set -Dversion.keycloak=$NEW_VERSION -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
-
-sed -i 's/\$\$VERSION\$\$/'"$NEW_VERSION"'/g' kubernetes/keycloak.yaml
-sed -i 's/\$\$VERSION\$\$/'"$NEW_VERSION"'/g' openshift/keycloak.yaml
-
-if [[ $NEW_VERSION == "999.0.0-SNAPSHOT" ]]; then
-  # Use the nightly versions of adapters
-  NPM_ADMIN_CLIENT="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz"
-  NPM_NODE_ADAPTER="https://github.com/keycloak/keycloak-nodejs-connect/releases/download/nightly/keycloak-nodejs-connect.tgz";
-else
-  NPM_ADMIN_CLIENT=$NEW_VERSION
-  NPM_NODE_ADAPTER=$NEW_VERSION
-fi
-
-# JS quickstart
-updateNpmDep js/spa/package.json "@keycloak/keycloak-admin-client"
-updateNpmDep js/spa/package.json "keycloak-js"
-
-# NodeJS quickstart
-updateNpmDep nodejs/resource-server/package.json "@keycloak/keycloak-admin-client"
-updateNpmDep nodejs/resource-server/package.json "keycloak-connect"
-
-echo "New Mvn Version: $NEW_VERSION" >&2
-echo "Used NPM dependency of keycloak-admin-client: $NPM_ADMIN_CLIENT" >&2
-echo "Used NPM dependency of node-adapter: $NPM_NODE_ADAPTER" >&2
+mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*


### PR DESCRIPTION
closes #639

- Updated `set-version.sh` script to update only project version, but not version of keycloak server

- Introduced `set-server-version.sh` script, which is used to update all the references to keycloak server, but does not update project version. I am planning to run this script from `keycloak-rel` during keycloak server release as during server release, we are not updating anymore the project version, but we need to update "keycloak server version" .

- Small adjustements needed in the `sed` commands as the string `$$VERSION$$` may not be available anymore in the `kubernetes.yml` and `openshift.yml` files. It would be needed to be able to replace also something like `version: 26.0.7` with something like `version: 26.0.8`, which was not supported by previous `sed` scripts, which assume string `$$VERSION$$`

- Updated server version to last released 26.0.7 used separate commit for that to not mix with updated bash scripts. (Hopefully in the future, this will be always done automatically in the quickstarts `main` branch for further keycloak server releases.)
