### PR TITLE
Replace DeploymentConfig in openshift quickstarts to avoid warning in output

### DIFF
--- a/openshift/keycloak.yaml
+++ b/openshift/keycloak.yaml
@@ -22,7 +22,7 @@ objects:
         - port: 8080
           targetPort: 8080
       selector:
-        deploymentConfig: '${APPLICATION_NAME}'
+        deployment: '${APPLICATION_NAME}'
   - apiVersion: v1
     id: '${APPLICATION_NAME}'
     kind: Route
@@ -38,8 +38,8 @@ objects:
         termination: edge
       to:
         name: '${APPLICATION_NAME}'
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         application: '${APPLICATION_NAME}'
@@ -47,14 +47,15 @@ objects:
     spec:
       replicas: 1
       selector:
-        deploymentConfig: '${APPLICATION_NAME}'
+        matchLabels:
+          deployment: '${APPLICATION_NAME}'
       strategy:
         type: Recreate
       template:
         metadata:
           labels:
             application: '${APPLICATION_NAME}'
-            deploymentConfig: '${APPLICATION_NAME}'
+            deployment: '${APPLICATION_NAME}'
           name: '${APPLICATION_NAME}'
         spec:
           containers:


### PR DESCRIPTION
Currently, the YAML manifests use DeploymentConfig and produce a deprecation warning:
```
$ oc new-project keycloak
$ oc process -n keycloak -f https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/openshift/keycloak.yaml ...snipped... | oc create -n keycloak -f -
service/keycloak created
route.route.openshift.io/keycloak created
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
deploymentconfig.apps.openshift.io/keycloak created
```
This PR updates to use Deployment, which doesn't produce warning now:
```
$ oc process -n keycloak -f https://raw.githubusercontent.com/xingxingxia/keycloak-quickstarts/refs/heads/replace-deploymentconfig-in-main/openshift/keycloak.yaml ...snipped... | oc create -n keycloak -f -
service/keycloak created
route.route.openshift.io/keycloak created
deployment.apps/keycloak created
```
@vmuzikar , could you help review/approve if having no objection? Thanks!




