### PR TITLE
Fix action-token quickstart tests and update README files

### DIFF
--- a/extension/action-token-authenticator/README.md
+++ b/extension/action-token-authenticator/README.md
@@ -35,9 +35,9 @@ flow. It is implemented by cooperation of authenticator and action token:
 System Requirements
 -------------------
 
-You need to have <span>Keycloak</span> running. It is recommended to use Keycloak 22 or later.
+You need to have <span>Keycloak</span> running. It is recommended to use Keycloak 26 or later.
 
-All you need to build this project is Java 11 (Java SDK 11) or later and Maven 3.6.3 or later.
+All you need to build this project is Java 17 (Java SDK 17) or later and Maven 3.6.3 or later.
 
 
 Build and Deploy the Quickstart
@@ -83,7 +83,7 @@ Integration test of the Quickstart
 ----------------------------------
 
 1. Make sure you have an Keycloak server running with an admin user in the `master` realm or use the provided docker image. Also make sure that server
-was started with the parameters as described above 
+was started with the parameters as described above and `action-token-example` is deployed to the server as described above
 2. You need to have Chrome browser installed and updated to the latest version
 3. Run `mvn -Pextension clean install`
 
@@ -102,9 +102,10 @@ You can download latest Wildfly server. If you run the mvn command as described 
 We also need to deploy simple WAR application to it and start the server. In Linux, the commands to do all of that could be for example like this:
 
 ```
-export WILDFY_VERSION=wildfly-28.0.1.Final
-cp -r target/$WILDFY_VERSION /tmp/
-cp target/deployments/wildfly_action-token-responder-example_action-token-responder-example.war /tmp/$WILDFY_VERSION/standalone/deployments/action-token-responder-example.war
+cd target
+export WILDFY_VERSION=`ls -d wildfly-*`
+cp -r $WILDFY_VERSION /tmp/
+cp deployments/wildfly_action-token-responder-example_action-token-responder-example.war /tmp/$WILDFY_VERSION/standalone/deployments/action-token-responder-example.war
 cd /tmp/$WILDFY_VERSION/bin
 ./standalone.sh
 ```

--- a/extension/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
+++ b/extension/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
@@ -35,8 +35,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.keycloak.Token;
 import org.keycloak.TokenCategory;
-import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserProfileResource;
 import org.keycloak.common.util.Base64;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.quickstart.actiontoken.authenticator.ExternalAppAuthenticator;
@@ -48,6 +48,7 @@ import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentatio
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.quickstart.test.page.LoginPage;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.util.JsonSerialization;
 import org.openqa.selenium.WebDriver;
 
@@ -148,6 +149,12 @@ public class ArquillianActionTokenWithAuthenticatorTest {
         final RealmRepresentation qsRealmRepresentation = qsRealm.toRepresentation();
         qsRealmRepresentation.setBrowserFlow("browser-copy");
         qsRealm.update(qsRealmRepresentation);
+
+        // Enable unmanaged attributes of user profile to be able to see the custom attributes
+        UserProfileResource userProfileRes = qsRealm.users().userProfile();
+        UPConfig cfg = userProfileRes.getConfiguration();
+        cfg.setUnmanagedAttributePolicy(UPConfig.UnmanagedAttributePolicy.ENABLED);
+        userProfileRes.update(cfg);
     }
 
     @AfterClass

--- a/extension/action-token-required-action/README.md
+++ b/extension/action-token-required-action/README.md
@@ -34,9 +34,9 @@ flow. It is implemented by cooperation of required action and action token:
 System Requirements
 -------------------
 
-You need to have <span>Keycloak</span> running. It is recommended to use Keycloak 22 or later.
+You need to have <span>Keycloak</span> running. It is recommended to use Keycloak 26 or later.
 
-All you need to build this project is Java 11 (Java SDK 11) or later and Maven 3.6.3 or later.
+All you need to build this project is Java 17 (Java SDK 17) or later and Maven 3.6.3 or later.
 
 
 Build and Deploy the Quickstart
@@ -45,7 +45,7 @@ Build and Deploy the Quickstart
 To build the provider, run the following maven command:
 
    ````
-   mvn -Pextension clean install
+   mvn -Pextension -DskipTests clean install
    ````
 
 To install the provider, copy the `target/action-token-req-action-example.jar` JAR file to the `providers` directory of the server distribution.
@@ -82,7 +82,7 @@ Integration test of the Quickstart
 ----------------------------------
 
 1. Make sure you have an Keycloak server running with an admin user in the `master` realm or use the provided docker image. Also make sure that server
-   was started with the parameters as described above
+   was started with the parameters as described above and `action-token-req-action-example` is deployed to the server as described above
 2. You need to have Chrome browser installed and updated to the latest version
 3. Run `mvn -Pextension clean install`
 
@@ -101,9 +101,10 @@ You can download latest Wildfly server. If you run the mvn command as described 
 We also need to deploy simple WAR application to it and start the server. In Linux, the commands to do all of that could be for example like this:
 
 ```
-export WILDFY_VERSION=wildfly-28.0.1.Final
-cp -r target/$WILDFY_VERSION /tmp/
-cp target/deployments/wildfly_action-token-responder-example_action-token-responder-example.war /tmp/$WILDFY_VERSION/standalone/deployments/action-token-responder-example.war
+cd target
+export WILDFY_VERSION=`ls -d wildfly-*`
+cp -r $WILDFY_VERSION /tmp/
+cp deployments/wildfly_action-token-responder-example_action-token-responder-example.war /tmp/$WILDFY_VERSION/standalone/deployments/action-token-responder-example.war
 cd /tmp/$WILDFY_VERSION/bin
 ./standalone.sh
 ```

--- a/extension/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
+++ b/extension/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
@@ -34,8 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.keycloak.Token;
 import org.keycloak.TokenCategory;
-import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserProfileResource;
 import org.keycloak.common.util.Base64;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.quickstart.actiontoken.reqaction.RedirectToExternalApplication;
@@ -45,6 +45,7 @@ import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.quickstart.test.page.LoginPage;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.util.JsonSerialization;
 import org.openqa.selenium.WebDriver;
 
@@ -135,6 +136,12 @@ public class ArquillianActionTokenTest {
             u.setRequiredActions(reqActions);
             qsRealm.users().get(u.getId()).update(u);
         });
+
+        // Enable unmanaged attributes of user profile to be able to see the custom attributes
+        UserProfileResource userProfileRes = qsRealm.users().userProfile();
+        UPConfig cfg = userProfileRes.getConfiguration();
+        cfg.setUnmanagedAttributePolicy(UPConfig.UnmanagedAttributePolicy.ENABLED);
+        userProfileRes.update(cfg);
     }
 
     @AfterClass


### PR DESCRIPTION
closes #693

- Set "unmanaged attributes" for the realm as quickstarts rely on some custom user attributes, which are set by the action-token handler and which are not returned as attributes of the user when not explicitly enabled on user-profile

- Updating README of action-token quickstarts as there are some outdated stuff in there
