### PR TITLE
Adjust quickstarts to the new format of --spi options

### DIFF
--- a/.github/scripts/start-local-server.sh
+++ b/.github/scripts/start-local-server.sh
@@ -9,16 +9,16 @@ if [ "$1" = "extension" ]; then
   echo "Adding default providers when starting Keycloak server";
 
   # extensions/event-listener-sysout example
-  SERVER_ARGS="--spi-events-listener-sysout-exclude-events=CODE_TO_TOKEN,REFRESH_TOKEN";
+  SERVER_ARGS="--spi-events-listener--sysout--exclude-events=CODE_TO_TOKEN,REFRESH_TOKEN";
 
   # extensions/action-token-authenticator example
-  SERVER_ARGS="$SERVER_ARGS --spi-action-token-handler-external-app-notification-hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko=";
+  SERVER_ARGS="$SERVER_ARGS --spi-action-token-handler--external-app-notification--hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko=";
 
   # extensions/action-token-required-action example
-  SERVER_ARGS="$SERVER_ARGS --spi-action-token-handler-external-app-reqaction-notification-hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko= --spi-required-action-redirect-to-external-application-external-application-url=http://127.0.0.1:8080/action-token-responder-example/external-action.jsp?token={TOKEN}";
+  SERVER_ARGS="$SERVER_ARGS --spi-action-token-handler--external-app-reqaction-notification--hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko= --spi-required-action-redirect-to-external-application-external-application-url=http://127.0.0.1:8080/action-token-responder-example/external-action.jsp?token={TOKEN}";
 
   # extensions/event-store-mem example
-  SERVER_ARGS="$SERVER_ARGS --spi-events-store-provider=in-mem";
+  SERVER_ARGS="$SERVER_ARGS --spi-events-store--provider=in-mem";
 
   # extension/extend-admin-console-spi
   SERVER_ARGS="$SERVER_ARGS --features=declarative-ui";

--- a/extension/action-token-authenticator/README.md
+++ b/extension/action-token-authenticator/README.md
@@ -54,7 +54,7 @@ To install the provider, copy the `target/action-token-example.jar` JAR file to 
 Finally, start the server as follows:
 
     ```
-    kc.[sh|bat] start-dev --http-port=8180 --spi-action-token-handler-external-app-notification-hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko=
+    kc.[sh|bat] start-dev --http-port=8180 --spi-action-token-handler--external-app-notification--hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko=
     ```
 
 If you see this startup command, you can notice the last configuration parameter, which is used for
@@ -62,6 +62,8 @@ a configuration of a single custom SPI implemented in this example:
 
  *  `external-app-notification` action token handler is given a HMAC secret key that
     is used in step 5 to verify that the invocation comes from the correct app.
+
+NOTE: When using Keycloak 26.2 or older, you may need to use this parameter for the last option instead `--spi-action-token-handler-external-app-notification-hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko=`
 
 NOTE: In production environment, you don't need to use the "confidential" parameters sent in the server startup command. It might be better
 to use configuration properties file for it, or even use the Keycloak Vault capabilities. See the Keycloak documentation for more details about provider

--- a/extension/action-token-required-action/README.md
+++ b/extension/action-token-required-action/README.md
@@ -54,8 +54,8 @@ Finally, start the server as follows:
 
     ```
     kc.[sh|bat] start-dev --http-port=8180 \
-      --spi-action-token-handler-external-app-reqaction-notification-hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko= \
-      --spi-required-action-redirect-to-external-application-external-application-url=http://127.0.0.1:8080/action-token-responder-example/external-action.jsp?token={TOKEN}
+      --spi-action-token-handler--external-app-reqaction-notification--hmac-secret=aSqzP4reFgWR4j94BDT1r+81QYp/NYbY9SBwXtqV1ko= \
+      --spi-required-action--redirect-to-external-application--external-application-url=http://127.0.0.1:8080/action-token-responder-example/external-action.jsp?token={TOKEN}
     ```
 
 If you see this startup command, you can notice the last two configuration parameters, which are used for
@@ -69,6 +69,9 @@ a configuration of two custom SPIs implemented in this example:
     flow. This URL contains special string `{TOKEN}` that is replaced with
     URL with action token. That URL is used by the external application to
     redirect back to Keycloak once its own flow is completed.
+
+NOTE: When using Keycloak 26.2 or older, you may need to use the parameter names without `--` inside the parameter names. So something like
+`--spi-action-token-handler-external-app-reqaction-notification-hmac-secret` and `--spi-required-action-redirect-to-external-application-external-application-url` .
 
 NOTE: In production environment, you don't need to use the "confidential" parameters sent in the server startup command, which in this case
 applies especially for the `hmac-secret` configuration parameter. It might be better to use configuration properties file for it, or even use

--- a/extension/event-listener-sysout/README.md
+++ b/extension/event-listener-sysout/README.md
@@ -38,8 +38,10 @@ To install the provider, copy the target/event-listener-sysout.jar JAR file to t
 Finally, start the server as follows:
 
     ```
-    kc.[sh|bat] start-dev --http-port=8180 --spi-events-listener-sysout-exclude-events=CODE_TO_TOKEN,REFRESH_TOKEN
+    kc.[sh|bat] start-dev --http-port=8180 --spi-events-listener--sysout--exclude-events=CODE_TO_TOKEN,REFRESH_TOKEN
     ```
+
+NOTE: When using Keycloak 26.2 or older, you may need to use this parameter for the last option instead `--spi-events-listener-sysout-exclude-events=CODE_TO_TOKEN,REFRESH_TOKEN`
 
 Then go to [Events Config](http://localhost:8180/admin/master/console/#/master/realm-settings/events) tab in the admin console and add `sysout` to Event Listeners.
 Save the changes afterwards. 

--- a/extension/event-store-mem/README.md
+++ b/extension/event-store-mem/README.md
@@ -54,6 +54,8 @@ Finally, start the server as follows:
     kc.[sh|bat] start-dev --http-port=8180 --spi-events-store-provider=in-mem
     ```
 
+NOTE: When using Keycloak 26.2 or older, you may need to use this parameter for the last option instead `--spi-events-store--provider=in-mem`
+
 Then go to [Events Config](http://localhost:8180/admin/master/console/#/master/realm-settings/events) tab in the admin console and enable
 login events and admin events by a toggle buttons `Save events` in the subtabs `User event settings` and `Admin event settings`. You can configure
 what event types should be stored and expiration of events. Save the changes afterwards.


### PR DESCRIPTION
closes #699

This is draft for now as it can be merged after Keycloak 26.3.0 release as it does not work with Keycloak 26.2 or older releases. This change is needed because of https://github.com/keycloak/keycloak/commit/76bc9fad