### PR TITLE
Utilise default jdbc-ping cache stack in Kubernetes quickstart

### DIFF
--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -19,13 +19,10 @@ kind: Service
 metadata:
   labels:
     app: keycloak
-  # Used to
   name: keycloak-discovery
 spec:
   selector:
     app: keycloak
-  # Allow not-yet-ready Pods to be visible to ensure the forming of a cluster if Pods come up concurrently
-  publishNotReadyAddresses: true
   clusterIP: None
   type: ClusterIP
 ---
@@ -75,9 +72,6 @@ spec:
               value: "true"
             - name: 'KC_CACHE'
               value: 'ispn'
-            # Use the Kubernetes configuration for distributed caches which is based on DNS
-            - name: 'KC_CACHE_STACK'
-              value: 'kubernetes'
             # Passing the Pod's IP primary address to the JGroups clustering as this is required in IPv6 only setups
             - name: POD_IP
               valueFrom:
@@ -86,7 +80,7 @@ spec:
             # Instruct JGroups which DNS hostname to use to discover other Keycloak nodes
             # Needs to be unique for each Keycloak cluster
             - name: JAVA_OPTS_APPEND
-              value: '-Djgroups.dns.query="keycloak-discovery" -Djgroups.bind.address=$(POD_IP)'
+              value: '-Djgroups.bind.address=$(POD_IP)'
             - name: 'KC_DB_URL_DATABASE'
               value: 'keycloak'
             - name: 'KC_DB_URL_HOST'


### PR DESCRIPTION
Closes keycloak/keycloak#41699