### PR TITLE
Stop using org.keycloak.quickstart.test.TestsHelper closes #597

### DIFF
--- a/extension/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
+++ b/extension/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
@@ -72,9 +72,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-import static org.keycloak.quickstart.test.TestsHelper.keycloakBaseUrl;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
 import static org.openqa.selenium.support.ui.ExpectedConditions.urlToBe;
 
@@ -84,7 +81,7 @@ public class ArquillianActionTokenWithAuthenticatorTest {
     private static final String EXTERNAL_APP = "action-token-responder-example";
 
     private static FluentTestsHelper fluentTestsHelper;
-    private static final String KEYCLOAK_URL = keycloakBaseUrl + "%s";
+    private static final String KEYCLOAK_URL = "http://localhost:8180" + "%s";
     private static final String REALM_QUICKSTART_ACTION_TOKEN = "quickstart-action-token";
 
     private static final String WEBAPP_SRC = "src/main/webapp";
@@ -121,8 +118,14 @@ public class ArquillianActionTokenWithAuthenticatorTest {
     @BeforeClass
     public static void setupClass() throws Exception {
         // Import realm
-        importTestRealm("admin", "admin", "/quickstart-realm.json");
-        fluentTestsHelper = new FluentTestsHelper(keycloakBaseUrl, "admin", "admin", "master", "admin-cli", REALM_QUICKSTART_ACTION_TOKEN).init();
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                REALM_QUICKSTART_ACTION_TOKEN)
+                .init();
+        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
         final RealmResource qsRealm = fluentTestsHelper.getKeycloakInstance().realm(REALM_QUICKSTART_ACTION_TOKEN);
 
         // Update authentication flow to use external application redirection
@@ -158,8 +161,8 @@ public class ArquillianActionTokenWithAuthenticatorTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
-        deleteRealm("admin", "admin", REALM_QUICKSTART_ACTION_TOKEN);
+    public static void tearDownClass() {
+        fluentTestsHelper.deleteRealm(REALM_QUICKSTART_ACTION_TOKEN);
     }
 
     @Before

--- a/extension/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
+++ b/extension/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
@@ -68,9 +68,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-import static org.keycloak.quickstart.test.TestsHelper.keycloakBaseUrl;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
 import static org.openqa.selenium.support.ui.ExpectedConditions.urlToBe;
 
@@ -81,7 +78,7 @@ public class ArquillianActionTokenTest {
     private static final String EXTERNAL_APP = "action-token-responder-example";
 
     private static FluentTestsHelper fluentTestsHelper;
-    private static final String KEYCLOAK_URL = keycloakBaseUrl + "%s";
+    private static final String KEYCLOAK_URL = "http://localhost:8180" + "%s";
     private static final String REALM_QUICKSTART_ACTION_TOKEN = "quickstart-action-token";
 
     private static final String WEBAPP_SRC = "src/main/webapp";
@@ -119,9 +116,14 @@ public class ArquillianActionTokenTest {
     @BeforeClass
     public static void setupClass() throws Exception {
         // Import realm
-        importTestRealm("admin", "admin", "/quickstart-realm.json");
-
-        fluentTestsHelper = new FluentTestsHelper(keycloakBaseUrl, "admin", "admin", "master", "admin-cli", REALM_QUICKSTART_ACTION_TOKEN).init();
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                REALM_QUICKSTART_ACTION_TOKEN)
+                .init();
+        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
         final RealmResource qsRealm = fluentTestsHelper.getKeycloakInstance().realm(REALM_QUICKSTART_ACTION_TOKEN);
 
         // Register the custom required action provider
@@ -145,8 +147,8 @@ public class ArquillianActionTokenTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
-        deleteRealm("admin", "admin", REALM_QUICKSTART_ACTION_TOKEN);
+    public static void tearDownClass() {
+        fluentTestsHelper.deleteRealm(REALM_QUICKSTART_ACTION_TOKEN);
     }
 
     @Before

--- a/extension/event-listener-sysout/src/test/java/org/keycloak/quickstart/event/listener/ArquillianSysoutEventListenerProviderTest.java
+++ b/extension/event-listener-sysout/src/test/java/org/keycloak/quickstart/event/listener/ArquillianSysoutEventListenerProviderTest.java
@@ -41,9 +41,6 @@ import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-import static org.keycloak.quickstart.test.TestsHelper.keycloakBaseUrl;
 
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
@@ -75,15 +72,20 @@ public class ArquillianSysoutEventListenerProviderTest {
     
     @BeforeClass
     public static void setupClass() throws IOException {
-        importTestRealm("admin", "admin", "/quickstart-realm.json");
-
-        fluentTestsHelper = new FluentTestsHelper(keycloakBaseUrl, "admin", "admin", "master", "admin-cli", REALM_QS_EVENT_SYSOUT).init();
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                REALM_QS_EVENT_SYSOUT)
+                .init();
+        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
         ADMIN_ID = fluentTestsHelper.getKeycloakInstance().realm(REALM_QS_EVENT_SYSOUT).users().search("test-admin").get(0).getId();
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
-        deleteRealm("admin", "admin", REALM_QS_EVENT_SYSOUT);
+    public static void tearDownClass() {
+        fluentTestsHelper.deleteRealm(REALM_QS_EVENT_SYSOUT);
     }
 
     @Before

--- a/extension/event-store-mem/src/test/java/org/keycloak/quickstart/event/storage/ArquillianEventStoreMemoryProviderTest.java
+++ b/extension/event-store-mem/src/test/java/org/keycloak/quickstart/event/storage/ArquillianEventStoreMemoryProviderTest.java
@@ -47,9 +47,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-import static org.keycloak.quickstart.test.TestsHelper.keycloakBaseUrl;
 
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
@@ -59,7 +56,9 @@ public class ArquillianEventStoreMemoryProviderTest {
 
     public static final String REALM_QS_EVENT_STORE = "event-store-mem";
 
-    public static final String KEYCLOAK_URL_CONSOLE = keycloakBaseUrl + "/admin/%s/console/#%s";
+    public static final String KEYCLOAK_URL = "http://localhost:8180";
+
+    public static final String KEYCLOAK_URL_CONSOLE = KEYCLOAK_URL + "/admin/%s/console/#%s";
 
     public static String ADMIN_ID;
 
@@ -73,15 +72,20 @@ public class ArquillianEventStoreMemoryProviderTest {
 
     @BeforeClass
     public static void setupClass() throws IOException {
-        importTestRealm("admin", "admin", "/quickstart-realm.json");
-
-        fluentTestsHelper = new FluentTestsHelper(keycloakBaseUrl, "admin", "admin", "master", "admin-cli", REALM_QS_EVENT_STORE).init();
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                REALM_QS_EVENT_STORE)
+                .init();
+        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
         ADMIN_ID = fluentTestsHelper.getKeycloakInstance().realm(REALM_QS_EVENT_STORE).users().search("test-admin").get(0).getId();
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
-        deleteRealm("admin", "admin", REALM_QS_EVENT_STORE);
+    public static void tearDownClass() {
+        fluentTestsHelper.deleteRealm(REALM_QS_EVENT_STORE);
     }
 
     @Before

--- a/jakarta/jaxrs-resource-server/src/test/java/org/keycloak/quickstart/jaxrs/JAXRSResourceServerTest.java
+++ b/jakarta/jaxrs-resource-server/src/test/java/org/keycloak/quickstart/jaxrs/JAXRSResourceServerTest.java
@@ -31,18 +31,18 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.keycloak.admin.client.Keycloak;
-import org.keycloak.quickstart.test.TestsHelper;
+import org.keycloak.quickstart.test.FluentTestsHelper;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-
-
 @RunWith(Arquillian.class)
 public class JAXRSResourceServerTest {
+
+    public static final String KEYCLOAK_URL = "http://localhost:8180";
+
+    private static FluentTestsHelper fluentTestsHelper;
 
     @ArquillianResource
     private URL contextRoot;
@@ -56,29 +56,30 @@ public class JAXRSResourceServerTest {
     }
 
     @AfterClass
-    public static void cleanUp() throws Exception {
-        deleteRealm("admin", "admin", "quickstart");
+    public static void cleanUp() {
+        fluentTestsHelper.deleteRealm("quickstart");
     }
 
     @BeforeClass
     public static void onBeforeClass() {
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                "quickstart")
+                .init();
         try {
-            importTestRealm("admin", "admin", "/quickstart-realm.json");
-        } catch (Exception e) {
+            fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+        } catch (IOException e) {
             e.printStackTrace();
         }
-    }
-
-    @Before
-    public void onBefore() {
-        TestsHelper.baseUrl = contextRoot.toString();
-        TestsHelper.testRealm = "quickstart";
     }
 
     @Test
     public void testSecuredEndpoint() {
         try {
-            Assert.assertTrue(TestsHelper.returnsForbidden("/secured"));
+            Assert.assertTrue(fluentTestsHelper.returnsForbidden("/secured"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -87,7 +88,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testAdminEndpoint() {
         try {
-            Assert.assertTrue(TestsHelper.returnsForbidden("/admin"));
+            Assert.assertTrue(fluentTestsHelper.returnsForbidden("/admin"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -96,7 +97,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testPublicEndpoint() {
         try {
-            Assert.assertFalse(TestsHelper.returnsForbidden("/public"));
+            Assert.assertFalse(fluentTestsHelper.returnsForbidden("/public"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -105,7 +106,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testSecuredEndpointWithAuth() {
         try {
-            Assert.assertTrue(TestsHelper.testGetWithAuth("/secured", getToken("alice", "alice")));
+            Assert.assertTrue(fluentTestsHelper.testGetWithAuth("/secured", getToken("alice", "alice")));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -114,7 +115,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testAdminEndpointWithAuthButNoRole() {
         try {
-            Assert.assertFalse(TestsHelper.testGetWithAuth("/admin", getToken("alice", "alice")));
+            Assert.assertFalse(fluentTestsHelper.testGetWithAuth("/admin", getToken("alice", "alice")));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -123,7 +124,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testAdminEndpointWithAuthAndRole() {
         try {
-            Assert.assertTrue(TestsHelper.testGetWithAuth("/admin", getToken("admin", "admin")));
+            Assert.assertTrue(fluentTestsHelper.testGetWithAuth("/admin", getToken("admin", "admin")));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -131,8 +132,8 @@ public class JAXRSResourceServerTest {
 
     public String getToken(String username, String password) {
         Keycloak keycloak = Keycloak.getInstance(
-                TestsHelper.keycloakBaseUrl,
-                TestsHelper.testRealm,
+                fluentTestsHelper.getKeycloakBaseUrl(),
+                fluentTestsHelper.getTestRealmName(),
                 username,
                 password,
                 "jakarta-jaxrs-resource-server",

--- a/jakarta/servlet-authz-client/src/test/java/org/keycloak/quickstart/ServletAuthzClientTest.java
+++ b/jakarta/servlet-authz-client/src/test/java/org/keycloak/quickstart/ServletAuthzClientTest.java
@@ -48,9 +48,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-import static org.keycloak.quickstart.test.TestsHelper.keycloakBaseUrl;
 import static org.openqa.selenium.support.ui.ExpectedConditions.not;
 import static org.openqa.selenium.support.ui.ExpectedConditions.urlToBe;
 
@@ -62,6 +59,8 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.urlToBe;
 public class ServletAuthzClientTest {
 
     private static final String APP_NAME = "jakarta-servlet-authz-client";
+
+    public static final String KEYCLOAK_URL = "http://localhost:8180";
 
     private static FluentTestsHelper fluentTestsHelper;
 
@@ -85,16 +84,22 @@ public class ServletAuthzClientTest {
     private URL contextRoot;
 
     @AfterClass
-    public static void cleanUp() throws Exception {
-        deleteRealm("admin", "admin", "quickstart");
+    public static void cleanUp() {
+        fluentTestsHelper.deleteRealm("quickstart");
     }
 
     @BeforeClass
     public static void onBeforeClass() {
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                "quickstart")
+                .init();
         try {
-            importTestRealm("admin", "admin", "/quickstart-realm.json");
-            fluentTestsHelper = new FluentTestsHelper(keycloakBaseUrl, "admin", "admin", "master", "admin-cli", "quickstart").init();
-        } catch (Exception e) {
+            fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }

--- a/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/SAMLServiceProviderTest.java
+++ b/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/SAMLServiceProviderTest.java
@@ -37,7 +37,6 @@ import org.keycloak.quickstart.test.page.IndexPage;
 import org.keycloak.quickstart.test.page.LoginPage;
 import org.keycloak.quickstart.test.page.ProfilePage;
 import org.keycloak.quickstart.test.FluentTestsHelper;
-import org.keycloak.quickstart.test.TestsHelper;
 import org.openqa.selenium.WebDriver;
 
 import java.io.File;
@@ -47,9 +46,6 @@ import java.net.URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
-import static org.keycloak.quickstart.test.TestsHelper.keycloakBaseUrl;
 
 /**
  * @author <a href="mailto:bruno@abstractj.org">Bruno Oliveira</a>
@@ -60,6 +56,7 @@ public class SAMLServiceProviderTest {
 
     private final static Logger log = Logger.getLogger(SAMLServiceProviderTest.class);
     private static final String APP_NAME = "servlet-saml-service-provider";
+    public static final String KEYCLOAK_URL = "http://localhost:8180";
 
     @Page
     private IndexPage indexPage;
@@ -76,10 +73,16 @@ public class SAMLServiceProviderTest {
     private static FluentTestsHelper fluentTestsHelper;
 
     static {
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                "quickstart")
+                .init();
         try {
-            importTestRealm("admin", "admin", "/quickstart-realm.json");
-            fluentTestsHelper = new FluentTestsHelper(keycloakBaseUrl, "admin", "admin", "master", "admin-cli", "quickstart").init();
-        } catch (Exception e) {
+            fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+        } catch (IOException e) {
             // print stacktrace here as an exception in a static initializer will lead to a class initialization problem
             e.printStackTrace();
             throw new RuntimeException(e);
@@ -100,8 +103,8 @@ public class SAMLServiceProviderTest {
     private URL contextRoot;
 
     @AfterClass
-    public static void cleanUp() throws IOException{
-        deleteRealm("admin","admin",TestsHelper.testRealm);
+    public static void cleanUp() {
+        fluentTestsHelper.deleteRealm(fluentTestsHelper.getTestRealmName());
     }
 
     @Before

--- a/spring/rest-authz-resource-server/src/test/java/org/keycloak/quickstart/AuthzResourceServerTest.java
+++ b/spring/rest-authz-resource-server/src/test/java/org/keycloak/quickstart/AuthzResourceServerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.quickstart.test.FluentTestsHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,9 +28,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.containsString;
-import static org.keycloak.quickstart.test.TestsHelper.deleteRealm;
-import static org.keycloak.quickstart.test.TestsHelper.importTestRealm;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -45,16 +46,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 public class AuthzResourceServerTest {
 
-	@AfterAll
-	public static void cleanUp() throws Exception {
-		deleteRealm("admin", "admin", "quickstart");
+    public static final String KEYCLOAK_URL = "http://localhost:8180";
+
+    private static FluentTestsHelper fluentTestsHelper;
+
+    @AfterAll
+	public static void cleanUp() {
+        fluentTestsHelper.deleteRealm("quickstart");
 	}
 
 	@BeforeAll
 	public static void onBeforeClass() {
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                "quickstart")
+                .init();
 		try {
-			importTestRealm("admin", "admin", "/realm-import.json");
-		} catch (Exception e) {
+            fluentTestsHelper.importTestRealm("/realm-import.json");
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak-quickstarts/issues/597

Deprecated TestsHelper and its methods were replaced by FluentTestsHelper and its methods.
