### PR TITLE
Adding all ports, and using KC 26.4 options

### DIFF
--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -79,8 +79,8 @@ spec:
                   fieldPath: status.podIP
             # Instruct JGroups which DNS hostname to use to discover other Keycloak nodes
             # Needs to be unique for each Keycloak cluster
-            - name: JAVA_OPTS_APPEND
-              value: '-Djgroups.bind.address=$(POD_IP)'
+            - name: KC_CACHE_EMBEDDED_NETWORK_BIND_ADDRESS
+              value: '$(POD_IP)'
             - name: 'KC_DB_URL_DATABASE'
               value: 'keycloak'
             - name: 'KC_DB_URL_HOST'
@@ -95,6 +95,10 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+            - name: jgroups
+              containerPort: 7800
+            - name: jgroups-fd
+              containerPort: 57800
           startupProbe:
             httpGet:
               path: /health/started


### PR DESCRIPTION
This brings the quickstart in line with the latest features in KC 26.4

I found that adding the ports is optional in OpenShift, still I think it is a good practice to add them for visibility. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
