### PR TITLE
Several test failures

### DIFF
--- a/extension/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
+++ b/extension/action-token-authenticator/src/test/java/org/keycloak/quickstart/ArquillianActionTokenWithAuthenticatorTest.java
@@ -81,7 +81,8 @@ public class ArquillianActionTokenWithAuthenticatorTest {
     private static final String EXTERNAL_APP = "action-token-responder-example";
 
     private static FluentTestsHelper fluentTestsHelper;
-    private static final String KEYCLOAK_URL = "http://localhost:8180" + "%s";
+    private static final String KEYCLOAK_URL_BASE = "http://localhost:8180";
+    private static final String KEYCLOAK_URL = KEYCLOAK_URL_BASE + "%s";
     private static final String REALM_QUICKSTART_ACTION_TOKEN = "quickstart-action-token";
 
     private static final String WEBAPP_SRC = "src/main/webapp";
@@ -118,14 +119,13 @@ public class ArquillianActionTokenWithAuthenticatorTest {
     @BeforeClass
     public static void setupClass() throws Exception {
         // Import realm
-        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL_BASE,
                 FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
                 FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
                 FluentTestsHelper.DEFAULT_ADMIN_REALM,
                 FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
-                REALM_QUICKSTART_ACTION_TOKEN)
-                .init();
-        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+                FluentTestsHelper.DEFAULT_ADMIN_REALM)
+                .init("/quickstart-realm.json");
         final RealmResource qsRealm = fluentTestsHelper.getKeycloakInstance().realm(REALM_QUICKSTART_ACTION_TOKEN);
 
         // Update authentication flow to use external application redirection

--- a/extension/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
+++ b/extension/action-token-required-action/src/test/java/org/keycloak/quickstart/ArquillianActionTokenTest.java
@@ -78,7 +78,8 @@ public class ArquillianActionTokenTest {
     private static final String EXTERNAL_APP = "action-token-responder-example";
 
     private static FluentTestsHelper fluentTestsHelper;
-    private static final String KEYCLOAK_URL = "http://localhost:8180" + "%s";
+    private static final String KEYCLOAK_URL_BASE = "http://localhost:8180";
+    private static final String KEYCLOAK_URL = KEYCLOAK_URL_BASE + "%s";
     private static final String REALM_QUICKSTART_ACTION_TOKEN = "quickstart-action-token";
 
     private static final String WEBAPP_SRC = "src/main/webapp";
@@ -116,14 +117,13 @@ public class ArquillianActionTokenTest {
     @BeforeClass
     public static void setupClass() throws Exception {
         // Import realm
-        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL_BASE,
                 FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
                 FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
                 FluentTestsHelper.DEFAULT_ADMIN_REALM,
                 FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
                 REALM_QUICKSTART_ACTION_TOKEN)
-                .init();
-        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+                .init("/quickstart-realm.json");
         final RealmResource qsRealm = fluentTestsHelper.getKeycloakInstance().realm(REALM_QUICKSTART_ACTION_TOKEN);
 
         // Register the custom required action provider

--- a/extension/event-listener-sysout/src/test/java/org/keycloak/quickstart/event/listener/ArquillianSysoutEventListenerProviderTest.java
+++ b/extension/event-listener-sysout/src/test/java/org/keycloak/quickstart/event/listener/ArquillianSysoutEventListenerProviderTest.java
@@ -78,8 +78,7 @@ public class ArquillianSysoutEventListenerProviderTest {
                 FluentTestsHelper.DEFAULT_ADMIN_REALM,
                 FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
                 REALM_QS_EVENT_SYSOUT)
-                .init();
-        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+                .init("/quickstart-realm.json");
         ADMIN_ID = fluentTestsHelper.getKeycloakInstance().realm(REALM_QS_EVENT_SYSOUT).users().search("test-admin").get(0).getId();
     }
 

--- a/extension/event-store-mem/src/test/java/org/keycloak/quickstart/event/storage/ArquillianEventStoreMemoryProviderTest.java
+++ b/extension/event-store-mem/src/test/java/org/keycloak/quickstart/event/storage/ArquillianEventStoreMemoryProviderTest.java
@@ -78,8 +78,7 @@ public class ArquillianEventStoreMemoryProviderTest {
                 FluentTestsHelper.DEFAULT_ADMIN_REALM,
                 FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
                 REALM_QS_EVENT_STORE)
-                .init();
-        fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+                .init("/quickstart-realm.json");
         ADMIN_ID = fluentTestsHelper.getKeycloakInstance().realm(REALM_QS_EVENT_STORE).users().search("test-admin").get(0).getId();
     }
 

--- a/extension/user-storage-simple/src/main/java/org/keycloak/quickstart/writeable/PropertyFileUserStorageProvider.java
+++ b/extension/user-storage-simple/src/main/java/org/keycloak/quickstart/writeable/PropertyFileUserStorageProvider.java
@@ -131,12 +131,12 @@ public class PropertyFileUserStorageProvider implements
     public Stream<UserModel> searchForUserStream(RealmModel realm, String search, Integer firstResult,
             Integer maxResults) {
         Predicate<String> predicate = "*".equals(search) ? username -> true : username -> username.contains(search);
-        return properties.keySet().stream()
+        Stream<UserModel> result = properties.keySet().stream()
                 .map(String.class::cast)
                 .filter(predicate)
-                .skip(firstResult)
-                .map(username -> getUserByUsername(realm, username))
-                .limit(maxResults);
+                .skip(firstResult != null ? firstResult : 0)
+                .map(username -> getUserByUsername(realm, username));
+        return maxResults != null ? result.limit(maxResults) : result;
     }
 
     @Override

--- a/jakarta/jaxrs-resource-server/src/test/java/org/keycloak/quickstart/jaxrs/JAXRSResourceServerTest.java
+++ b/jakarta/jaxrs-resource-server/src/test/java/org/keycloak/quickstart/jaxrs/JAXRSResourceServerTest.java
@@ -62,15 +62,14 @@ public class JAXRSResourceServerTest {
 
     @BeforeClass
     public static void onBeforeClass() {
-        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
-                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
-                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
-                FluentTestsHelper.DEFAULT_ADMIN_REALM,
-                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
-                "quickstart")
-                .init();
         try {
-            fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+            fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                    FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                    FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                    FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                    FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                    "quickstart")
+                    .init("/quickstart-realm.json");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -79,7 +78,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testSecuredEndpoint() {
         try {
-            Assert.assertTrue(fluentTestsHelper.returnsForbidden("/secured"));
+            Assert.assertTrue(fluentTestsHelper.returnsForbidden(contextRoot.toString() + "/secured"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -88,8 +87,8 @@ public class JAXRSResourceServerTest {
     @Test
     public void testAdminEndpoint() {
         try {
-            Assert.assertTrue(fluentTestsHelper.returnsForbidden("/admin"));
-        } catch (IOException e) {
+            Assert.assertTrue(fluentTestsHelper.returnsForbidden(contextRoot.toString() + "/admin"));
+        } catch (Exception e) {
             Assert.fail();
         }
     }
@@ -97,7 +96,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testPublicEndpoint() {
         try {
-            Assert.assertFalse(fluentTestsHelper.returnsForbidden("/public"));
+            Assert.assertFalse(fluentTestsHelper.returnsForbidden(contextRoot.toString() + "/public"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -106,7 +105,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testSecuredEndpointWithAuth() {
         try {
-            Assert.assertTrue(fluentTestsHelper.testGetWithAuth("/secured", getToken("alice", "alice")));
+            Assert.assertTrue(fluentTestsHelper.testGetWithAuth(contextRoot.toString() + "/secured", getToken("alice", "alice")));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -115,7 +114,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testAdminEndpointWithAuthButNoRole() {
         try {
-            Assert.assertFalse(fluentTestsHelper.testGetWithAuth("/admin", getToken("alice", "alice")));
+            Assert.assertFalse(fluentTestsHelper.testGetWithAuth(contextRoot.toString() + "/admin", getToken("alice", "alice")));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -124,7 +123,7 @@ public class JAXRSResourceServerTest {
     @Test
     public void testAdminEndpointWithAuthAndRole() {
         try {
-            Assert.assertTrue(fluentTestsHelper.testGetWithAuth("/admin", getToken("admin", "admin")));
+            Assert.assertTrue(fluentTestsHelper.testGetWithAuth(contextRoot.toString() + "/admin", getToken("admin", "admin")));
         } catch (IOException e) {
             Assert.fail();
         }

--- a/jakarta/servlet-authz-client/src/test/java/org/keycloak/quickstart/ServletAuthzClientTest.java
+++ b/jakarta/servlet-authz-client/src/test/java/org/keycloak/quickstart/ServletAuthzClientTest.java
@@ -90,15 +90,14 @@ public class ServletAuthzClientTest {
 
     @BeforeClass
     public static void onBeforeClass() {
-        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
-                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
-                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
-                FluentTestsHelper.DEFAULT_ADMIN_REALM,
-                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
-                "quickstart")
-                .init();
         try {
-            fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+            fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                    FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                    FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                    FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                    FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                    "quickstart")
+                    .init("/quickstart-realm.json");
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/SAMLServiceProviderTest.java
+++ b/jakarta/servlet-saml-service-provider/src/test/java/org/keycloak/quickstart/SAMLServiceProviderTest.java
@@ -73,17 +73,17 @@ public class SAMLServiceProviderTest {
     private static FluentTestsHelper fluentTestsHelper;
 
     static {
-        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
-                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
-                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
-                FluentTestsHelper.DEFAULT_ADMIN_REALM,
-                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
-                "quickstart")
-                .init();
         try {
-            fluentTestsHelper.importTestRealm("/quickstart-realm.json");
+            fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+                    FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+                    FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+                    FluentTestsHelper.DEFAULT_ADMIN_REALM,
+                    FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+                    "quickstart")
+                    .init("/quickstart-realm.json");
         } catch (IOException e) {
-            // print stacktrace here as an exception in a static initializer will lead to a class initialization problem
+            // print stacktrace here as an exception in a static initializer will lead to a
+            // class initialization problem
             e.printStackTrace();
             throw new RuntimeException(e);
         }

--- a/misc/keycloak-quickstarts-test-helper/src/main/java/org/keycloak/quickstart/test/FluentTestsHelper.java
+++ b/misc/keycloak-quickstarts-test-helper/src/main/java/org/keycloak/quickstart/test/FluentTestsHelper.java
@@ -164,6 +164,20 @@ public class FluentTestsHelper implements Closeable {
     }
 
     /**
+     * Initialization method importing the test realm.
+     *
+     * @param realmJsonPath The file to import
+     * @return <code>this</code>
+     */
+    public FluentTestsHelper init(String realmJsonPath) throws IOException {
+        keycloak = createKeycloakInstance(keycloakBaseUrl, adminRealm, adminUserName, adminPassword, adminClient);
+        isInitialized = true;
+        importTestRealm(realmJsonPath);
+        accessToken = generateInitialAccessToken();
+        return this;
+    }
+
+    /**
      * @return Returns <code>true</code> if this helper has been initialized.
      */
     public boolean isInitialized() {
@@ -414,7 +428,7 @@ public class FluentTestsHelper implements Closeable {
         CloseableHttpClient client = HttpClientBuilder.create().build();
 
         try {
-            HttpGet get = new HttpGet(keycloakBaseUrl + endpoint);
+            HttpGet get = new HttpGet(endpoint);
             get.addHeader("Authorization", "Bearer " + token);
 
             HttpResponse response = client.execute(get);
@@ -444,7 +458,7 @@ public class FluentTestsHelper implements Closeable {
     public boolean returnsForbidden(String endpoint) throws IOException {
         CloseableHttpClient client = HttpClientBuilder.create().build();
         try {
-            HttpGet get = new HttpGet(keycloakBaseUrl + endpoint);
+            HttpGet get = new HttpGet(endpoint);
             HttpResponse response = client.execute(get);
             if (response.getStatusLine().getStatusCode() == 403 || response.getStatusLine().getStatusCode() == 401) {
                 return true;

--- a/spring/rest-authz-resource-server/src/test/java/org/keycloak/quickstart/AuthzResourceServerTest.java
+++ b/spring/rest-authz-resource-server/src/test/java/org/keycloak/quickstart/AuthzResourceServerTest.java
@@ -57,15 +57,14 @@ public class AuthzResourceServerTest {
 
 	@BeforeAll
 	public static void onBeforeClass() {
-        fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
-                FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
-                FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
-                FluentTestsHelper.DEFAULT_ADMIN_REALM,
-                FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
-                "quickstart")
-                .init();
 		try {
-            fluentTestsHelper.importTestRealm("/realm-import.json");
+			fluentTestsHelper = new FluentTestsHelper(KEYCLOAK_URL,
+					FluentTestsHelper.DEFAULT_ADMIN_USERNAME,
+					FluentTestsHelper.DEFAULT_ADMIN_PASSWORD,
+					FluentTestsHelper.DEFAULT_ADMIN_REALM,
+					FluentTestsHelper.DEFAULT_ADMIN_CLIENT,
+					"quickstart")
+					.init("/realm-import.json");
 		} catch (IOException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Closes #712

Several fixes for tests. The change for using `FluentTestsHelper` instead of `TestsHelper` introduced some problems. I have created another `init` method that allows to init and import the realm json at the same time. Fixing the provider for properties to also consider that `firstResult` and `maxResults` can be null.
