### PR TITLE
fix(kuberentes): Fix PostgreSQL mount path for PostgreSQL 17

### DIFF
--- a/kubernetes/keycloak.yaml
+++ b/kubernetes/keycloak.yaml
@@ -157,7 +157,7 @@ spec:
           volumeMounts:
             # Using volume mount for PostgreSQL's data folder as it is otherwise not writable
             - name: postgres-data
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
       volumes:
         - name: postgres-data
           emptyDir: {}


### PR DESCRIPTION
Close #715

The volume mount path for the PostgreSQL container is `/var/lib/postgresql`, but for PostgreSQL version 17 and earlier container images, the expected mount path is `/var/lib/postgresql/data`. 
https://hub.docker.com/_/postgres

Therefore, I have fixed the mount path to `/var/lib/postgresql/data`.

With this fix, data persistence can be achieved by simply replacing the volume section in the PostgreSQL manifest with a PVC.
```diff
      volumes:
        - name: postgres-data
-         emptyDir: {}
+         persistentVolumeClaim:
+           claimName: postgres-pvc
```
