### PR TITLE
Closes #772. Fixing bug by updating empty state button locator

### DIFF
--- a/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/ExtendedAdminPage.java
+++ b/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/ExtendedAdminPage.java
@@ -34,7 +34,7 @@ public class ExtendedAdminPage {
     private WebElement todoMenuItem;
 
     @FindBy(
-            xpath = "//button[@data-testid='there-are-no-items-empty-action']"
+            xpath = "//*[text()='Create item' or @data-testid='there-are-no-items-empty-action']"
     )
     private WebElement addButton;
 


### PR DESCRIPTION
Closes #772
- When the Todo list has no data, the UI renders a button with data-testid='there-are-no-items-empty-action'
- If data exists in the database (due to previous test runs or specific test execution ordering), the UI renders an anchor link instead: <a href="#/master/page-section/Todo/add">Create item</a>

Updated the locator to handle both the empty and populated states.