### PR TITLE
Imp for the admin UI and admin API on a separate hostname and port for Traefik

### DIFF
--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -379,6 +379,27 @@ This prevents direct clients from injecting a `X-Forwarded-Tls-Client-Cert` head
 Combined with the network isolation (Keycloak is only reachable via the internal backend network)
 and header stripping at Traefik, this provides defense in depth against certificate spoofing.
 
+## Optional: Admin UI and Admin API on a dedicated hostname and port
+
+By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints,
+protected only by the `ip-allowlist` middleware. For stricter network-level isolation, you can move
+them to a dedicated hostname and port (8444) so they can be independently firewalled.
+
+To enable this, uncomment the marked lines in the following files:
+
+**`docker-compose.yaml`**
+- `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` — tells each Keycloak node to serve the Admin UI and Admin API on the admin hostname.
+- Port `8444:8444` under the `traefik` service — exposes the admin port on the host.
+
+**`traefik.yaml`**
+- The `keycloak-admin` entrypoint — adds a second Traefik entrypoint listening on port 8444.
+
+**`keycloak.yaml`**
+- The `keycloak-admin` router — routes all traffic coming on the `keycloak-admin` entrypoint to the Keycloak service, restricted to the `ip-allowlist`.
+- Comment out the `keycloak-internal` router — it is no longer needed, as the admin paths are now handled exclusively by the dedicated `keycloak-admin` router on port 8444. Leaving both enabled would cause the `keycloak-internal` router to match admin paths on port 8443 as well.
+
+> **Note:** With this setup, any request to an admin path on port 8443 will fall through to the `keycloak-public` router, which only matches `/realms/`, `/resources/`, and `/.well-known/`. Admin paths on port 8443 will return a 404.
+
 ## Resources
 
 - [Traefik Documentation](https://doc.traefik.io/traefik/)

--- a/proxy/traefik/reencrypt/docker-compose.yaml
+++ b/proxy/traefik/reencrypt/docker-compose.yaml
@@ -1,7 +1,7 @@
 # =========================================================================
 # NOTE: ADMIN UI hostname and port ISOLATION
-#   - Uncomment 'KC_HOSTNAME_ADMIN' in keycloak1 and keycloak2 (line 39 and 94)
-#   - Uncomment port '8444:8444' under the traefik service (line 191)
+#   - Uncomment 'KC_HOSTNAME_ADMIN' in keycloak1 and keycloak2
+#   - Uncomment port '8444:8444' under the traefik service
 # =========================================================================
 services:
   postgres:
@@ -35,8 +35,9 @@ services:
       # Hostname / HTTPS
       KC_PROXY_HEADERS: xforwarded
       KC_HOSTNAME: "https://${KC_HOST}:8443"
-    # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
-    # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
+      # ADMIN UI hostname and port ISOLATION
+      # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
+      # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -90,6 +91,7 @@ services:
       # Hostname / HTTPS
       KC_PROXY_HEADERS: xforwarded
       KC_HOSTNAME: "https://${KC_HOST}:8443"
+      # ADMIN UI hostname and port ISOLATION
       # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
       # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
@@ -187,8 +189,9 @@ services:
           selinux: z
     ports:
       - "8443:8443"
-     #  Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
-     # - "8444:8444"
+      # ADMIN UI hostname and port ISOLATION
+      # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
+      # - "8444:8444"
       - "8080:8080"
     networks:
       - frontend

--- a/proxy/traefik/reencrypt/docker-compose.yaml
+++ b/proxy/traefik/reencrypt/docker-compose.yaml
@@ -1,3 +1,8 @@
+# =========================================================================
+# NOTE: ADMIN UI hostname and port ISOLATION
+#   - Uncomment 'KC_HOSTNAME_ADMIN' in keycloak1 and keycloak2 (line 39 and 94)
+#   - Uncomment port '8444:8444' under the traefik service (line 191)
+# =========================================================================
 services:
   postgres:
     image: mirror.gcr.io/postgres:18
@@ -29,7 +34,9 @@ services:
       KC_HEALTH_ENABLED: "true"
       # Hostname / HTTPS
       KC_PROXY_HEADERS: xforwarded
-      KC_HOSTNAME: "${KC_HOST}"
+      KC_HOSTNAME: "https://${KC_HOST}:8443"
+    # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
+    # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -82,7 +89,9 @@ services:
       KC_HEALTH_ENABLED: "true"
       # Hostname / HTTPS
       KC_PROXY_HEADERS: xforwarded
-      KC_HOSTNAME: "${KC_HOST}"
+      KC_HOSTNAME: "https://${KC_HOST}:8443"
+      # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
+      # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -178,10 +187,9 @@ services:
           selinux: z
     ports:
       - "8443:8443"
+     #  Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
+     # - "8444:8444"
       - "8080:8080"
-    depends_on:
-      - keycloak1
-      - keycloak2
     networks:
       - frontend
       - backend

--- a/proxy/traefik/reencrypt/keycloak.yaml
+++ b/proxy/traefik/reencrypt/keycloak.yaml
@@ -1,3 +1,8 @@
+# =========================================================================
+# NOTE: ADMIN UI hostname and port ISOLATION
+#   - Uncomment Admin router section (keycloak-admin)(lines 103-112)
+#   - Comment keycloak-internal section (lines 88-98)
+# =========================================================================
 tls:
   certificates:
     - certFile: /certs/traefik-external/cert.pem
@@ -91,6 +96,20 @@ http:
         - ip-allowlist
       tls: { }
       service: keycloak
+
+# Uncomment this Admin router section if you have the admin UI and admin API on a separate hostname and port
+#    # Admin router: routes traffic from the admin hostname.
+#    # Restricted to the allowed source IP ranges.
+#    keycloak-admin:
+#      entryPoints:
+#        - keycloak-admin
+#      rule: "PathPrefix(`/`)"
+#      middlewares:
+#        - filter-headers
+#        - pass-client-cert
+#        - ip-allowlist
+#      tls: { }
+#      service: keycloak
 
   services:
     keycloak:

--- a/proxy/traefik/reencrypt/keycloak.yaml
+++ b/proxy/traefik/reencrypt/keycloak.yaml
@@ -1,7 +1,7 @@
 # =========================================================================
 # NOTE: ADMIN UI hostname and port ISOLATION
-#   - Uncomment Admin router section (keycloak-admin)(lines 103-112)
-#   - Comment keycloak-internal section (lines 88-98)
+#   - Uncomment Admin router section (keycloak-admin)
+#   - Comment keycloak-internal section
 # =========================================================================
 tls:
   certificates:
@@ -97,6 +97,7 @@ http:
       tls: { }
       service: keycloak
 
+# ADMIN UI hostname and port ISOLATION
 # Uncomment this Admin router section if you have the admin UI and admin API on a separate hostname and port
 #    # Admin router: routes traffic from the admin hostname.
 #    # Restricted to the allowed source IP ranges.

--- a/proxy/traefik/reencrypt/traefik.yaml
+++ b/proxy/traefik/reencrypt/traefik.yaml
@@ -1,6 +1,13 @@
+# =========================================================================
+# NOTE: ADMIN UI hostname and port ISOLATION
+#   - Uncomment keycloak-admin entry point (keycloak-admin)(lines 8-9)
+# =========================================================================
 entryPoints:
   keycloak:
     address: ":8443"
+# Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
+#  keycloak-admin:
+#    address: ":8444"
 api:
   dashboard: true
   insecure: true

--- a/proxy/traefik/reencrypt/traefik.yaml
+++ b/proxy/traefik/reencrypt/traefik.yaml
@@ -1,10 +1,11 @@
 # =========================================================================
 # NOTE: ADMIN UI hostname and port ISOLATION
-#   - Uncomment keycloak-admin entry point (keycloak-admin)(lines 8-9)
+#   - Uncomment keycloak-admin entry point (keycloak-admin)
 # =========================================================================
 entryPoints:
   keycloak:
     address: ":8443"
+# ADMIN UI hostname and port ISOLATION
 # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
 #  keycloak-admin:
 #    address: ":8444"


### PR DESCRIPTION
This PR the admin UI and admin API on a separate hostname and port for Traefik POC

Closes keycloak/keycloak#49683
Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
