### PR TITLE
Imp for the admin UI and admin API on a separate hostname and port for ha proxy

### DIFF
--- a/proxy/haproxy/reencrypt/README.md
+++ b/proxy/haproxy/reencrypt/README.md
@@ -389,6 +389,46 @@ and header stripping at HAProxy, this provides defense in depth against certific
 **IMPORTANT:** HAProxy support for `KC_SPI_X509CERT_LOOKUP__HAPROXY__SSL_CERT_CHAIN` is only available from Keycloak 26.7
 see [#49180](https://github.com/keycloak/keycloak/issues/49180).
 
+## Optional: Admin UI and Admin API on a dedicated port
+
+By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints,
+protected only by the source IP filtering (`is_allowed_src`). For stricter network-level isolation, you can move
+them to a dedicated port (8444) so they can be independently firewalled.
+
+The dedicated admin port uses the **same hostname** as the public port, so the existing external certificate
+already covers it and no additional Subject Alternative Name is required. Because the admin port and the public
+port share the same HAProxy frontend, the header filtering and client certificate forwarding described above
+apply to both automatically.
+
+> **Note:** Setting `hostname-admin` only changes the URLs Keycloak generates for the Admin Console and Admin API.
+> It does not stop the Admin API from also answering on the public frontend URL — restricting administration access
+> to the dedicated port must be enforced at the reverse proxy, which is what the rules below do.
+> See the [hostname guide](https://www.keycloak.org/server/hostname).
+
+To enable this, uncomment the marked lines in the following files:
+
+**`docker-compose.yaml`**
+- `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` — tells each Keycloak node to serve the Admin UI and Admin API on the admin port. (`KC_HOSTNAME` is already set to the required `https://${KC_HOST}:8443` URL form.)
+- Port `8444:8444` under the `haproxy` service — exposes the admin port on the host.
+
+**`haproxy.cfg`**
+- The second `bind *:8444 ...` line — makes the frontend also listen on the admin port.
+- Comment the default `http-request deny unless is_public_path or is_allowed_src` rule and uncomment the three isolation rules below it:
+  ```
+  acl is_admin_port dst_port 8444
+  http-request deny if !is_admin_port !is_public_path
+  http-request deny if is_admin_port !is_allowed_src
+  ```
+
+These rules route by destination port:
+
+- **Public port (8443):** only the public paths (`/realms/`, `/resources/`, `/.well-known/`) are served; any other path, including the Admin Console and Admin API, is denied.
+- **Admin port (8444):** all paths are served, but only to the allowed source IP ranges.
+
+> **Note:** With this setup, any request to an admin path on port 8443 is denied with an HTTP 403 response. Because the admin port shares the hostname with the public port, In production, restrict the admin port (8444) to an internal/management network at the firewall.
+
+
+
 ## Resources
 
 - [HAProxy Configuration Manual](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/)

--- a/proxy/haproxy/reencrypt/README.md
+++ b/proxy/haproxy/reencrypt/README.md
@@ -395,8 +395,10 @@ By default, the Admin UI and Admin API are served on the same port (8443) as the
 protected only by the source IP filtering (`is_allowed_src`). For stricter network-level isolation, you can move
 them to a dedicated port (8444) so they can be independently firewalled.
 
-The dedicated admin port uses the **same hostname** as the public port, so the existing external certificate
-already covers it and no additional Subject Alternative Name is required. Because the admin port and the public
+In this example, the dedicated admin port uses the same hostname as the public port, so the existing external certificate
+already covers it and no additional Subject Alternative Name is required. In your environment, you are free to configure this differently. 
+
+Because the admin port and the public
 port share the same HAProxy frontend, the header filtering and client certificate forwarding described above
 apply to both automatically.
 

--- a/proxy/haproxy/reencrypt/docker-compose.yaml
+++ b/proxy/haproxy/reencrypt/docker-compose.yaml
@@ -37,9 +37,9 @@ services:
       # Hostname / HTTPS
       KC_PROXY_HEADERS: forwarded
       KC_HOSTNAME: "https://${KC_HOST}:8443"
-    # ADMIN UI hostname and port ISOLATION
-    # Uncomment if you want the admin UI and admin API on a separate port.
-    # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
+      # ADMIN UI hostname and port ISOLATION
+      # Uncomment if you want the admin UI and admin API on a separate port.
+      # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -95,9 +95,9 @@ services:
       # Hostname / HTTPS
       KC_PROXY_HEADERS: forwarded
       KC_HOSTNAME: "https://${KC_HOST}:8443"
-    # ADMIN UI hostname and port ISOLATION
-    # Uncomment if you want the admin UI and admin API on a separate port.
-    # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
+      # ADMIN UI hostname and port ISOLATION
+      # Uncomment if you want the admin UI and admin API on a separate port.
+      # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -178,9 +178,9 @@ services:
     ports:
       - "8443:8443"
       - "8404:8404"
-       # ADMIN UI hostname and port ISOLATION
-       # Uncomment if you want the admin UI and admin API on a separate port.
-      #- "8444:8444"
+      # ADMIN UI hostname and port ISOLATION
+      # Uncomment if you want the admin UI and admin API on a separate port.
+      # - "8444:8444"
     depends_on:
       - keycloak1
       - keycloak2

--- a/proxy/haproxy/reencrypt/docker-compose.yaml
+++ b/proxy/haproxy/reencrypt/docker-compose.yaml
@@ -1,3 +1,10 @@
+# =========================================================================
+# NOTE: ADMIN UI hostname and port ISOLATION
+#   - Uncomment 'KC_HOSTNAME_ADMIN' in keycloak1 and keycloak2
+#     (KC_HOSTNAME is already set to the required https URL form)
+#   - Uncomment port '8444:8444' under the haproxy service
+#   - In haproxy.cfg: enable the 'bind *:8444' and the dst_port rules
+# =========================================================================
 services:
   postgres:
     image: mirror.gcr.io/postgres:18
@@ -29,7 +36,10 @@ services:
       KC_HEALTH_ENABLED: "true"
       # Hostname / HTTPS
       KC_PROXY_HEADERS: forwarded
-      KC_HOSTNAME: "${KC_HOST}"
+      KC_HOSTNAME: "https://${KC_HOST}:8443"
+    # ADMIN UI hostname and port ISOLATION
+    # Uncomment if you want the admin UI and admin API on a separate port.
+    # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -84,7 +94,10 @@ services:
       KC_HEALTH_ENABLED: "true"
       # Hostname / HTTPS
       KC_PROXY_HEADERS: forwarded
-      KC_HOSTNAME: "${KC_HOST}"
+      KC_HOSTNAME: "https://${KC_HOST}:8443"
+    # ADMIN UI hostname and port ISOLATION
+    # Uncomment if you want the admin UI and admin API on a separate port.
+    # KC_HOSTNAME_ADMIN: "https://${KC_HOST}:8444"
       KC_HTTPS_CERTIFICATE_FILE: /opt/keycloak/certs/cert.pem
       KC_HTTPS_CERTIFICATE_KEY_FILE: /opt/keycloak/certs/key.pem
       KC_HTTPS_CLIENT_AUTH: required
@@ -165,6 +178,9 @@ services:
     ports:
       - "8443:8443"
       - "8404:8404"
+       # ADMIN UI hostname and port ISOLATION
+       # Uncomment if you want the admin UI and admin API on a separate port.
+      #- "8444:8444"
     depends_on:
       - keycloak1
       - keycloak2

--- a/proxy/haproxy/reencrypt/haproxy.cfg
+++ b/proxy/haproxy/reencrypt/haproxy.cfg
@@ -27,7 +27,7 @@ frontend https_front
 
     # ADMIN UI hostname and port ISOLATION
     # Uncomment to serve the Admin Console and Administration REST API on a dedicated port.
-   # bind *:8444 ssl crt /mnt/certs/haproxy-external.pem ca-file /mnt/certs/client-ca-chain.pem verify optional
+    # bind *:8444 ssl crt /mnt/certs/haproxy-external.pem ca-file /mnt/certs/client-ca-chain.pem verify optional
 
     # Not recommended in production
     # HTTP headers can contain sensitive information (falls under the purview of the GDPR or similar)
@@ -75,12 +75,10 @@ frontend https_front
 
     # ADMIN UI hostname and port ISOLATION
     # Comment the single "deny" line above and uncomment the three lines below to
-    # serve administration endpoints only on the dedicated admin port (8444):
-    #  - public port (8443): only the public paths are served
-    # KC_HOST=localhost docker compose up -d haproxy - admin  port (8444): everything, restricted to the allowed source IPs
-    #acl is_admin_port dst_port 8444
-    #http-request deny if !is_admin_port !is_public_path
-    #http-request deny if is_admin_port !is_allowed_src
+    # serve administration endpoints only on the dedicated admin port (8444).
+    # acl is_admin_port dst_port 8444
+    # http-request deny if !is_admin_port !is_public_path
+    # http-request deny if is_admin_port !is_allowed_src
 
     default_backend keycloak_back
 

--- a/proxy/haproxy/reencrypt/haproxy.cfg
+++ b/proxy/haproxy/reencrypt/haproxy.cfg
@@ -1,3 +1,11 @@
+# =========================================================================
+# NOTE: ADMIN UI hostname and port ISOLATION
+#   - Uncomment the second 'bind *:8444 ...' line below
+#   - Comment the default "deny unless is_public_path or is_allowed_src" rule
+#     and uncomment the three "ADMIN port isolation" rules beneath it
+#   - In docker-compose.yaml: set KC_HOSTNAME to the https URL form, uncomment
+#     KC_HOSTNAME_ADMIN, and uncomment the '8444:8444' port on the haproxy service
+# =========================================================================
 global
     log stdout format raw local0
 
@@ -16,6 +24,10 @@ frontend https_front
     # bind *:8443 ssl crt /mnt/certs/haproxy-external.pem
     bind *:8443 ssl crt /mnt/certs/haproxy-external.pem ca-file /mnt/certs/client-ca-chain.pem verify optional
     mode http
+
+    # ADMIN UI hostname and port ISOLATION
+    # Uncomment to serve the Admin Console and Administration REST API on a dedicated port.
+   # bind *:8444 ssl crt /mnt/certs/haproxy-external.pem ca-file /mnt/certs/client-ca-chain.pem verify optional
 
     # Not recommended in production
     # HTTP headers can contain sensitive information (falls under the purview of the GDPR or similar)
@@ -60,6 +72,15 @@ frontend https_front
     acl is_allowed_src src 172.16.0.0/12
 
     http-request deny unless is_public_path or is_allowed_src
+
+    # ADMIN UI hostname and port ISOLATION
+    # Comment the single "deny" line above and uncomment the three lines below to
+    # serve administration endpoints only on the dedicated admin port (8444):
+    #  - public port (8443): only the public paths are served
+    # KC_HOST=localhost docker compose up -d haproxy - admin  port (8444): everything, restricted to the allowed source IPs
+    #acl is_admin_port dst_port 8444
+    #http-request deny if !is_admin_port !is_public_path
+    #http-request deny if is_admin_port !is_allowed_src
 
     default_backend keycloak_back
 


### PR DESCRIPTION
This PR the admin UI and admin API on a separate hostname and port for Ha proxy POC.

Closes keycloak/keycloak#49871
Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
