### PR TITLE
Adding tests in extension for cancel and revert button 

### DIFF
--- a/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/ExtendAdminConsoleTest.java
+++ b/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/ExtendAdminConsoleTest.java
@@ -22,6 +22,7 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -102,6 +103,53 @@ public class ExtendAdminConsoleTest {
         adminConsole.clickSave();
 
         Assert.assertTrue(adminConsole.isSaved());
+    }
+
+    @Test
+    public void testPageProviderCancelButton() throws Exception {
+        adminConsole.clickTodoMenuItem();
+        waitForPageToLoad();
+        Assert.assertTrue(adminConsole.isOverviewPage());
+
+        // Navigate to the form page by clicking Add button
+        adminConsole.clickAddButton();
+        waitForPageToLoad();
+
+
+        adminConsole.fillTodoForm("test task", "test description");
+        Assume.assumeTrue("Cancel button not present in this server build", adminConsole.isCancelButtonPresent());
+        String detailPageUrl = adminConsole.getCurrentUrl();
+
+        adminConsole.clickCancel();
+        waitForPageToLoad();
+
+        // Verify redirect occurred - URL should change back to overview page
+        String currentUrl = adminConsole.getCurrentUrl();
+        Assert.assertNotEquals(detailPageUrl, currentUrl);
+        Assert.assertTrue(adminConsole.isOverviewPage());
+    }
+
+    @Test
+    public void testTabProviderRevertButton() throws Exception {
+        realmSettingsAttributePage.navigateTo();
+        waitForPageToLoad();
+
+        Assert.assertTrue(realmSettingsAttributePage.logoInputExists());
+
+
+        String initialValue = "http://initial.com/logo.png";
+        realmSettingsAttributePage.fillLogoField(initialValue);
+        Assume.assumeTrue("Revert button not present in this server build", realmSettingsAttributePage.isRevertButtonPresent());
+
+        Assert.assertEquals(initialValue, realmSettingsAttributePage.getLogoFieldValue());
+
+        realmSettingsAttributePage.clickRevertButton();
+        waitForPageToLoad();
+
+        // The revert should reset the form without redirecting
+        String revertedValue = realmSettingsAttributePage.getLogoFieldValue();
+        Assert.assertNotEquals(initialValue, revertedValue);
+        Assert.assertTrue(realmSettingsAttributePage.logoInputExists());
     }
 
     @Test

--- a/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/ExtendedAdminPage.java
+++ b/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/ExtendedAdminPage.java
@@ -25,6 +25,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.jboss.arquillian.graphene.Graphene;
+import java.util.concurrent.TimeUnit;
 
 public class ExtendedAdminPage {
 
@@ -52,6 +54,11 @@ public class ExtendedAdminPage {
             xpath = "//button[@data-testid='save']"
     )
     private WebElement saveButton;
+
+    @FindBy(
+            xpath = "//*[@data-testid='cancel']"
+    )
+    private WebElement cancelButton;
 
     @FindBy(
             css = ".pf-m-success"
@@ -90,6 +97,26 @@ public class ExtendedAdminPage {
 
     public void clickSave() {
         saveButton.click();
+    }
+
+    public void clickCancel() {
+        WebElement button = new WebDriverWait(webDriver, Duration.ofSeconds(15))
+                .until(ExpectedConditions.elementToBeClickable(cancelButton));
+        button.click();
+    }
+
+    public boolean isCancelButtonPresent() {
+        try {
+            new WebDriverWait(webDriver, Duration.ofSeconds(15))
+                    .until(ExpectedConditions.elementToBeClickable(cancelButton));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getCurrentUrl() {
+        return webDriver.getCurrentUrl();
     }
 
     public boolean isSaved() {

--- a/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/RealmSettingsAttributePage.java
+++ b/extension/extend-admin-console-spi/src/test/java/org/keycloak/quickstart/RealmSettingsAttributePage.java
@@ -1,9 +1,15 @@
 package org.keycloak.quickstart;
 
 import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.jboss.arquillian.graphene.Graphene;
+import java.util.concurrent.TimeUnit;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import java.time.Duration;
 
 import static org.keycloak.quickstart.ExtendedAdminPage.ADMIN_CONSOLE;
 
@@ -18,6 +24,11 @@ public class RealmSettingsAttributePage {
             xpath = "//button[@data-testid='save']"
     )
     private WebElement saveButton;
+
+    @FindBy(
+            xpath = "//button[@data-testid='cancel']"
+    )
+    private WebElement revertButton;
 
     @FindBy(
             css = ".pf-m-success"
@@ -37,6 +48,31 @@ public class RealmSettingsAttributePage {
     public void saveLogoField(String logo) {
         logoInput.sendKeys(logo);
         saveButton.click();
+    }
+
+    public void fillLogoField(String logo) {
+        logoInput.clear();
+        logoInput.sendKeys(logo);
+    }
+
+    public String getLogoFieldValue() {
+        return logoInput.getAttribute("value");
+    }
+
+    public void clickRevertButton() {
+        WebElement button = new WebDriverWait(webDriver, Duration.ofSeconds(15))
+                .until( ExpectedConditions.elementToBeClickable(revertButton));
+        button.click();
+    }
+
+    public boolean isRevertButtonPresent() {
+        try {
+            new WebDriverWait(webDriver, Duration.ofSeconds(15))
+                    .until(ExpectedConditions.elementToBeClickable(revertButton));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     public boolean isSaved() {


### PR DESCRIPTION
Closes #765. 

Added testPageProviderCancelButton() and testTabProviderRevertButton() in extend-admin-console-spi 