### PR TITLE
Imp for isolating the master realm from the public internet to minimize the attack surface for traefik proxy in quickstart repo

### DIFF
--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -379,6 +379,30 @@ This prevents direct clients from injecting a `X-Forwarded-Tls-Client-Cert` head
 Combined with the network isolation (Keycloak is only reachable via the internal backend network)
 and header stripping at Traefik, this provides defense in depth against certificate spoofing.
 
+## Master realm and public router priority constraints:**
+
+The commented `keycloak-master` router provides an explicit administrative isolation layer for Keycloak's core configuration boundary by separating the default management realm from custom application realms.
+
+```yaml
+  routers:
+#    keycloak-master:
+#      entryPoints:
+#        - keycloak
+#      rule: "PathRegexp(`^/realms/master(/|$)`)"
+#      priority: 100
+#      middlewares:
+#        - filter-headers
+#        - pass-client-cert
+#        - ip-allowlist
+#      tls: { }
+#      service: keycloak
+```
+When activated, the router targets requests matching the regular expression ^/realms/master(/|$). This rule matches core management traffic (such as token requests or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
+
+Rule Overlap Resolution: Because the path /realms/master/ matches both the explicit master regex rule and the broad PathPrefix(\/realms/`)` string in the public router, a priority conflict occurs. Traefik handles overlapping matching metrics by executing the router with the highest numeric priority value first.
+
+The explicit use of priority: 100 on the master router and priority: 50 on the public router defines a strict evaluation pipeline.
+
 ## Optional: Admin UI and Admin API on a dedicated hostname and port
 
 By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints,

--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -379,9 +379,12 @@ This prevents direct clients from injecting a `X-Forwarded-Tls-Client-Cert` head
 Combined with the network isolation (Keycloak is only reachable via the internal backend network)
 and header stripping at Traefik, this provides defense in depth against certificate spoofing.
 
-## Master realm and public router priority constraints:**
+## Restrict login to the master realm to internal IP addresses
 
-The `keycloak-master` router provides an explicit administrative isolation layer for Keycloak's core configuration boundary by separating the default management realm from custom application realms.
+As a security best practice, prevent logins to the administrative `master` realm from public IP addresses.
+Use the following steps to allow accessing the respective URLs only from allowed internal IP addresses. 
+
+The `keycloak-master` router isolates the default management realm from custom application realms.
 
 ```yaml
   routers:
@@ -397,11 +400,12 @@ The `keycloak-master` router provides an explicit administrative isolation layer
       tls: { }
       service: keycloak
 ```
-This router targets requests matching the regular expression ^/realms/master(/|$). This rule matches core management traffic (such as token requests or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
 
-Rule Overlap Resolution: Because the path /realms/master/ matches both the explicit master regex rule and the broad PathPrefix(\/realms/`)` string in the public router, a priority conflict occurs. Traefik handles overlapping matching metrics by executing the router with the highest numeric priority value first.
+This router targets requests matching the regular expression `^/realms/master(/|$)`. This rule matches core management traffic (such as token requests, logins or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
 
-The explicit use of priority: 100 on the master router and priority: 50 on the public router defines a strict evaluation pipeline.
+Rule Overlap Resolution: Because the path `/realms/master/` matches both the explicit master regex rule and the broad ``PathPrefix(`/realms/`)`` string in the public router, a priority conflict occurs. Traefik handles overlapping matching metrics by executing the router with the highest numeric priority value first.
+
+The explicit use of `priority: 100` on the master router and `priority: 50` on the public router defines a strict evaluation pipeline.
 
 ## Optional: Admin UI and Admin API on a dedicated hostname and port
 

--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -381,23 +381,23 @@ and header stripping at Traefik, this provides defense in depth against certific
 
 ## Master realm and public router priority constraints:**
 
-The commented `keycloak-master` router provides an explicit administrative isolation layer for Keycloak's core configuration boundary by separating the default management realm from custom application realms.
+The `keycloak-master` router provides an explicit administrative isolation layer for Keycloak's core configuration boundary by separating the default management realm from custom application realms.
 
 ```yaml
   routers:
-#    keycloak-master:
-#      entryPoints:
-#        - keycloak
-#      rule: "PathRegexp(`^/realms/master(/|$)`)"
-#      priority: 100
-#      middlewares:
-#        - filter-headers
-#        - pass-client-cert
-#        - ip-allowlist
-#      tls: { }
-#      service: keycloak
+    keycloak-master:
+      entryPoints:
+        - keycloak
+      rule: "PathRegexp(`^/realms/master(/|$)`)"
+      priority: 100
+      middlewares:
+        - filter-headers
+        - pass-client-cert
+        - ip-allowlist
+      tls: { }
+      service: keycloak
 ```
-When activated, the router targets requests matching the regular expression ^/realms/master(/|$). This rule matches core management traffic (such as token requests or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
+This router targets requests matching the regular expression ^/realms/master(/|$). This rule matches core management traffic (such as token requests or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
 
 Rule Overlap Resolution: Because the path /realms/master/ matches both the explicit master regex rule and the broad PathPrefix(\/realms/`)` string in the public router, a priority conflict occurs. Traefik handles overlapping matching metrics by executing the router with the highest numeric priority value first.
 

--- a/proxy/traefik/reencrypt/keycloak.yaml
+++ b/proxy/traefik/reencrypt/keycloak.yaml
@@ -28,7 +28,7 @@ http:
     filter-headers:
       headers:
         customRequestHeaders:
-          # Strip the forwarding headers to prevent spoofing and ensure that Keycloak receives the correct client information.
+          # Strip forwarding headers to prevent spoofing
           Forwarded: ""
           X-Forwarded-For: ""
           X-Forwarded-Proto: ""
@@ -71,20 +71,35 @@ http:
           - "172.16.0.0/12"
 
   routers:
+# Uncomment this router if you want to allow access to the master realm for administrative purposes.
+#    keycloak-master:
+#      entryPoints:
+#        - keycloak
+#      rule: "PathRegexp(`^/realms/master(/|$)`)"
+#      priority: 100
+#      middlewares:
+#        - filter-headers
+#        - pass-client-cert
+#        - ip-allowlist
+#      tls: { }
+#      service: keycloak
+
     # Public router: exposes only the paths needed for external clients.
     # Accessible from any source IP address.
     keycloak-public:
       entryPoints:
         - keycloak
       rule: "PathPrefix(`/realms/`) || PathPrefix(`/resources/`) || PathPrefix(`/.well-known/`)"
+      # Uncomment if  keycloak-master router is enabled.  This ensures that the keycloak-master router takes precedence over the keycloak-public router.
+#      priority: 50
       middlewares:
         - filter-headers
         - pass-client-cert
       tls: { }
       service: keycloak
 
-    # Internal router: all other paths are restricted to the allowed source IP ranges.
-    # This prevents external access to the Admin API and Admin Console.
+    # Internal router: all other paths (like /admin/) fall through to here.
+    # Restricted strictly to the allowed source IP ranges.
     keycloak-internal:
       entryPoints:
         - keycloak

--- a/proxy/traefik/reencrypt/keycloak.yaml
+++ b/proxy/traefik/reencrypt/keycloak.yaml
@@ -71,7 +71,7 @@ http:
           - "172.16.0.0/12"
 
   routers:
-#  Allow access to the master realm for administrative purposes.
+    # Allow access to the master realm for administrative purposes only from allowed IP addresses
     keycloak-master:
       entryPoints:
         - keycloak
@@ -90,7 +90,7 @@ http:
       entryPoints:
         - keycloak
       rule: "PathPrefix(`/realms/`) || PathPrefix(`/resources/`) || PathPrefix(`/.well-known/`)"
-      #This ensures that the keycloak-master router takes precedence over the keycloak-public router.
+      # This ensures that the keycloak-master router takes precedence over the keycloak-public router.
       priority: 50
       middlewares:
         - filter-headers

--- a/proxy/traefik/reencrypt/keycloak.yaml
+++ b/proxy/traefik/reencrypt/keycloak.yaml
@@ -71,18 +71,18 @@ http:
           - "172.16.0.0/12"
 
   routers:
-# Uncomment this router if you want to allow access to the master realm for administrative purposes.
-#    keycloak-master:
-#      entryPoints:
-#        - keycloak
-#      rule: "PathRegexp(`^/realms/master(/|$)`)"
-#      priority: 100
-#      middlewares:
-#        - filter-headers
-#        - pass-client-cert
-#        - ip-allowlist
-#      tls: { }
-#      service: keycloak
+#  Allow access to the master realm for administrative purposes.
+    keycloak-master:
+      entryPoints:
+        - keycloak
+      rule: "PathRegexp(`^/realms/master(/|$)`)"
+      priority: 100
+      middlewares:
+        - filter-headers
+        - pass-client-cert
+        - ip-allowlist
+      tls: { }
+      service: keycloak
 
     # Public router: exposes only the paths needed for external clients.
     # Accessible from any source IP address.
@@ -90,8 +90,8 @@ http:
       entryPoints:
         - keycloak
       rule: "PathPrefix(`/realms/`) || PathPrefix(`/resources/`) || PathPrefix(`/.well-known/`)"
-      # Uncomment if  keycloak-master router is enabled.  This ensures that the keycloak-master router takes precedence over the keycloak-public router.
-#      priority: 50
+      #This ensures that the keycloak-master router takes precedence over the keycloak-public router.
+      priority: 50
       middlewares:
         - filter-headers
         - pass-client-cert


### PR DESCRIPTION
This PR shows implementation  for isolating the master realm from the public internet to minimize the attack surface for traefik proxy .

Closes keycloak/keycloak#50259
Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
