### PR TITLE
Imp for Isolating the master realm from the public internet to minimze the attack surface for HAproxy in quickstart repo

### DIFF
--- a/proxy/haproxy/reencrypt/README.md
+++ b/proxy/haproxy/reencrypt/README.md
@@ -389,6 +389,21 @@ and header stripping at HAProxy, this provides defense in depth against certific
 **IMPORTANT:** HAProxy support for `KC_SPI_X509CERT_LOOKUP__HAPROXY__SSL_CERT_CHAIN` is only available from Keycloak 26.7
 see [#49180](https://github.com/keycloak/keycloak/issues/49180).
 
+## Restrict login to the master realm to internal IP addresses
+
+As a security best practice, prevent logins to the administrative `master` realm from public IP addresses.
+Use the following steps to allow accessing the respective URLs only from allowed internal IP addresses.
+```
+acl is_master_realm path /realms/master
+acl is_master_realm path_beg /realms/master/
+http-request deny if is_master_realm !is_allowed_src
+```
+This configuration targets requests matching the administrative paths /realms/master or starting with /realms/master/. This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
+
+Rule Overlap Resolution: Because the path /realms/master/ matches both the explicit master path rules and a broad public application rule (like path_beg /realms/), a conflict occurs. HAProxy handles overlapping matching metrics sequentially by executing http-request instructions from top to bottom.
+
+The explicit placement of the is_master_realm denial rule at the very top of the request processing block defines a strict evaluation pipeline. This acts as a higher priority filter, ensuring malicious external traffic hitting the master path is rejected instantly before any broader, public routing logic is evaluated.
+
 ## Optional: Admin UI and Admin API on a dedicated port
 
 By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints,

--- a/proxy/haproxy/reencrypt/README.md
+++ b/proxy/haproxy/reencrypt/README.md
@@ -393,16 +393,17 @@ see [#49180](https://github.com/keycloak/keycloak/issues/49180).
 
 As a security best practice, restrict access to the administrative `master` realm endpoints from public IP addresses.
 Use the following steps to allow access to these URLs only from allowed internal IP addresses.
+
 ```
 acl is_master_realm path /realms/master
 acl is_master_realm path_beg /realms/master/
 http-request deny if is_master_realm !is_allowed_src
 ```
-This configuration targets requests matching the administrative paths /realms/master or starting with /realms/master/. This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
+This configuration targets requests matching the administrative paths `/realms/master` or starting with `/realms/master/`. This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
 
-Rule Overlap Resolution: Because the path /realms/master/ matches both the explicit master path rules and a broad public application rule (like path_beg /realms/), a conflict occurs. HAProxy handles overlapping matching metrics sequentially by executing http-request instructions from top to bottom.
+Because the quickstart treats `/realms/` as a public path, this explicit deny is required to keep the administrative realm from being reachable from the public internet.
 
-The explicit placement of the is_master_realm denial rule at the very top of the request processing block defines a strict evaluation pipeline. This acts as a higher priority filter, ensuring malicious external traffic hitting the master path is rejected instantly before any broader, public routing logic is evaluated.
+The explicit placement of the `is_master_realm` denial rule at the very top of the request processing block defines a strict evaluation pipeline. This acts as a higher priority filter, ensuring malicious external traffic hitting the master path is rejected instantly before any broader, public routing logic is evaluated.
 
 ## Optional: Admin UI and Admin API on a dedicated port
 

--- a/proxy/haproxy/reencrypt/README.md
+++ b/proxy/haproxy/reencrypt/README.md
@@ -389,10 +389,10 @@ and header stripping at HAProxy, this provides defense in depth against certific
 **IMPORTANT:** HAProxy support for `KC_SPI_X509CERT_LOOKUP__HAPROXY__SSL_CERT_CHAIN` is only available from Keycloak 26.7
 see [#49180](https://github.com/keycloak/keycloak/issues/49180).
 
-## Restrict login to the master realm to internal IP addresses
+## Restrict access to the master realm to internal IP addresses
 
-As a security best practice, prevent logins to the administrative `master` realm from public IP addresses.
-Use the following steps to allow accessing the respective URLs only from allowed internal IP addresses.
+As a security best practice, restrict access to the administrative `master` realm endpoints from public IP addresses.
+Use the following steps to allow access to these URLs only from allowed internal IP addresses.
 ```
 acl is_master_realm path /realms/master
 acl is_master_realm path_beg /realms/master/

--- a/proxy/haproxy/reencrypt/haproxy.cfg
+++ b/proxy/haproxy/reencrypt/haproxy.cfg
@@ -71,7 +71,7 @@ frontend https_front
     acl is_allowed_src src 127.0.0.0/8
     acl is_allowed_src src 172.16.0.0/12
 
-    #Config for isolating the master realm from public internet.
+    # Config for isolating the master realm from public internet.
     acl is_master_realm path /realms/master
     acl is_master_realm path_beg /realms/master/
     http-request deny if is_master_realm !is_allowed_src

--- a/proxy/haproxy/reencrypt/haproxy.cfg
+++ b/proxy/haproxy/reencrypt/haproxy.cfg
@@ -71,7 +71,7 @@ frontend https_front
     acl is_allowed_src src 127.0.0.0/8
     acl is_allowed_src src 172.16.0.0/12
 
-#   Confog for isolating the master realm from public internet.
+    #Config for isolating the master realm from public internet.
     acl is_master_realm path /realms/master
     acl is_master_realm path_beg /realms/master/
     http-request deny if is_master_realm !is_allowed_src

--- a/proxy/haproxy/reencrypt/haproxy.cfg
+++ b/proxy/haproxy/reencrypt/haproxy.cfg
@@ -71,6 +71,11 @@ frontend https_front
     acl is_allowed_src src 127.0.0.0/8
     acl is_allowed_src src 172.16.0.0/12
 
+#   Confog for isolating the master realm from public internet.
+    acl is_master_realm path /realms/master
+    acl is_master_realm path_beg /realms/master/
+    http-request deny if is_master_realm !is_allowed_src
+
     http-request deny unless is_public_path or is_allowed_src
 
     # ADMIN UI hostname and port ISOLATION


### PR DESCRIPTION
This PR show how a config to Imp for Isolating the master realm from the public internet to minimze the attack surface for HAproxy in quickstart repo is added.

Closes keycloak/keycloak#50260

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
