### PR TITLE
Minor fix of HAProxy stats listener unauthenticated on published port : 8404

### DIFF
--- a/proxy/haproxy/reencrypt/haproxy.cfg
+++ b/proxy/haproxy/reencrypt/haproxy.cfg
@@ -106,3 +106,7 @@ listen stats
     stats enable
     stats uri /stats
     stats refresh 10s
+    stats realm Haproxy\ Statistics
+    # Change the username and password before any production deployment. The default is admin/admin.
+    stats auth admin:admin
+    stats hide-version


### PR DESCRIPTION

configuration.

Closes https://github.com/keycloak/keycloak-quickstarts/issues/785

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
