### PR TITLE
Added a warning /comment about the usage of the api.insure in production

### DIFF
--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -139,7 +139,7 @@ api:
   insecure: true
 ```
 
-Enables the Traefik dashboard and API on port 8080 without authentication. The dashboard is accessible at http://127.0.0.1:8080/dashboard/ and the API at http://127.0.0.1:8080/api/. **This must never be used in production.**
+Enables the Traefik dashboard and API on port 8080 without authentication. The dashboard is accessible at http://127.0.0.1:8080/dashboard/ and the API at http://127.0.0.1:8080/api/. **In a production environment, secure the API and dashboard with authentication and authorization.**
 
 ### keycloak.yaml — dynamic configuration:
 

--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -135,10 +135,11 @@ Defines the entry point on port 8443 where Traefik accepts incoming HTTPS connec
 **Dashboard:**
 ```yaml
 api:
+  dashboard: true
   insecure: true
 ```
 
-Enables the Traefik dashboard on port 8080 without authentication. The dashboard is accessible at http://127.0.0.1:8080/dashboard/. **This must never be used in production.**
+Enables the Traefik dashboard and API on port 8080 without authentication. The dashboard is accessible at http://127.0.0.1:8080/dashboard/ and the API at http://127.0.0.1:8080/api/. **This must never be used in production.**
 
 ### keycloak.yaml — dynamic configuration:
 

--- a/proxy/traefik/reencrypt/README.md
+++ b/proxy/traefik/reencrypt/README.md
@@ -114,6 +114,34 @@ docker compose down
 
 ## Traefik configuration
 
+The Traefik setup is split into two files:
+
+- traefik.yaml — static configuration loaded at startup (entry points, dashboard, and providers).
+- keycloak.yaml — dynamic configuration for runtime routing rules, services, and health checks.
+
+Both files are required for this setup to work correctly.
+
+### traefik.yaml — static configuration:
+
+**Entry point for TLS traffic:**
+```yaml
+entryPoints:
+  keycloak:
+    address: ":8443"
+```
+
+Defines the entry point on port 8443 where Traefik accepts incoming HTTPS connections and re-encrypts them before forwarding to Keycloak.
+
+**Dashboard:**
+```yaml
+api:
+  insecure: true
+```
+
+Enables the Traefik dashboard on port 8080 without authentication. The dashboard is accessible at http://127.0.0.1:8080/dashboard/. **This must never be used in production.**
+
+### keycloak.yaml — dynamic configuration:
+
 The key parts of `keycloak.yaml` are explained below. The `keycloak.yaml` file contains the
 dynamic configuration — routing rules, TLS certificates, and backend transport settings.
 

--- a/proxy/traefik/reencrypt/traefik.yaml
+++ b/proxy/traefik/reencrypt/traefik.yaml
@@ -9,6 +9,7 @@ entryPoints:
 # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
 #  keycloak-admin:
 #    address: ":8444"
+# DEMO ONLY — remove api.insecure for production
 api:
   dashboard: true
   insecure: true

--- a/proxy/traefik/reencrypt/traefik.yaml
+++ b/proxy/traefik/reencrypt/traefik.yaml
@@ -9,7 +9,7 @@ entryPoints:
 # Uncomment if you want to have the admin UI and admin API on a separate hostname and port.
 #  keycloak-admin:
 #    address: ":8444"
-# DEMO ONLY — remove api.insecure for production
+# DEMO ONLY — remove api.insecure: true for production, instead add authentication and authorization
 api:
   dashboard: true
   insecure: true


### PR DESCRIPTION
This PR covers the below:

Add # DEMO ONLY — remove api.insecure for production comment in traefik.yaml.
Add the same warning callout paragraph that the passthrough quickstart uses.

Closes https://github.com/keycloak/keycloak-quickstarts/issues/784

Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak.

Please send pull requests to the `main` branch. Not to any other branch.
-->
